### PR TITLE
Added MAILSMTP_ERROR_AUTH_TIMEOUT

### DIFF
--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1300,6 +1300,10 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
   while (1) {
     r = read_response(session);
     switch (r) {
+    case 0:
+      res = MAILSMTP_ERROR_STREAM;
+      goto free_sasl_conn;
+        
     case 220:
     case 235:
       res = MAILSMTP_NO_ERROR;


### PR DESCRIPTION
I have had and issue with office365 server. I wrote about it in #181, but it doesn't seem that I explained the problem clearly.
So I want to try again.

When I connect to office365 smtp server it often makes '235 2.7.0 Authentication successful' response with delay. 
Libetpan doesn't check if we received 235 response (We should receive it by RFC4954).
If delay was, it finishes auth process at last 334 response and decides that everything is Ok.
It might be true, if we input correct username/password.
BUT, when you send next command, it receives 235 response from prev AUTH command which shifts correct responses and it results in to brake other requests. Other request gives you incorrect error MAILSMTP_ERROR_UNEXPECTED_CODE in this case. The error doesn't tell you anything about problem and you must to debug and find that you should increase session timeout.

I propose this pull request to fix the issue. What do you think about this change?

Log:

```
2015-01-13 12:22:38.394 Mail[61524:4432369] smtp: 220 AM2PR03CA0017.outlook.office365.com Microsoft ESMTP MAIL Service ready at Tue, 13 Jan 2015 10:22:37 +0000
2015-01-13 12:22:38.394 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.394 Mail[61524:4432369] smtp: EHLO Foxs-Macmini.local
2015-01-13 12:22:38.463 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.463 Mail[61524:4432369] smtp: 250-AM2PR03CA0017.outlook.office365.com Hello [89.209.104.185]
250-SIZE 78643200
250-PIPELINING
250-DSN
250-ENHANCEDSTATUSCODES
250-STARTTLS
250-8BITMIME
250-BINARYMIME
250 CHUNKING
2015-01-13 12:22:38.464 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.464 Mail[61524:4432369] smtp: STARTTLS
2015-01-13 12:22:38.529 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.529 Mail[61524:4432369] smtp: 220 2.0.0 SMTP server ready
2015-01-13 12:22:38.808 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.809 Mail[61524:4432369] smtp: EHLO Foxs-Macmini.local
2015-01-13 12:22:38.874 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.875 Mail[61524:4432369] smtp: 250-AM2PR03CA0017.outlook.office365.com Hello [89.209.104.185]
250-SIZE 78643200
250-PIPELINING
250-DSN
250-ENHANCEDSTATUSCODES
250-AUTH LOGIN
250-8BITMIME
250-BINARYMIME
250 CHUNKING
2015-01-13 12:22:38.875 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.875 Mail[61524:4432369] smtp: AUTH LOGIN
2015-01-13 12:22:38.941 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.941 Mail[61524:4432369] smtp: 334 VXNlcm5hbWU6
2015-01-13 12:22:38.941 Mail[61524:4432369] smtp: 
2015-01-13 12:22:38.941 Mail[61524:4432369] smtp: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX==
2015-01-13 12:22:39.007 Mail[61524:4432369] smtp: 
2015-01-13 12:22:39.007 Mail[61524:4432369] smtp: 334 UGFzc3dvcmQ6
2015-01-13 12:22:39.008 Mail[61524:4432369] smtp: 
2015-01-13 12:22:39.008 Mail[61524:4432369] smtp: XXXXXXXXXXX=
2015-01-13 12:22:56.529 Mail[61524:4432369] smtp: 
2015-01-13 12:22:56.529 Mail[61524:4432369] smtp: 235 2.7.0 Authentication successful target host BY2PR01MB299.prod.exchangelabs.com
2015-01-13 12:22:56.529 Mail[61524:4432369] smtp: 
```