### PR TITLE
Fix IMAP ID send.

### DIFF
--- a/src/low-level/imap/mailimap_id_sender.c
+++ b/src/low-level/imap/mailimap_id_sender.c
@@ -88,7 +88,7 @@ static int mailimap_id_param_send(mailstream * fd, struct mailimap_id_param * pa
 {
   int r;
   
-  r = mailimap_astring_send(fd, param->idpa_name);
+  r = mailimap_quoted_send(fd, param->idpa_name);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
@@ -102,7 +102,7 @@ static int mailimap_id_param_send(mailstream * fd, struct mailimap_id_param * pa
       return r;
   }
   else {
-    r = mailimap_astring_send(fd, param->idpa_value);
+    r = mailimap_quoted_send(fd, param->idpa_value);
     if (r != MAILIMAP_NO_ERROR)
       return r;
   }


### PR DESCRIPTION
Use mailimap_quoted_send rather than mailimap_astring_send when
sending names and values inside mailimap_id_param_send.
This means skipping the "workaround for buggy Courier-IMAP that
does not accept quoted-strings for fields name but prefer atoms"
and instead always sending quoted strings.

RFC 2971 (with reference to RFC 2060) is clear that these fields
may only be quoted strings or literals, not atoms.  Yahoo's server
rejects this command when atoms are sent (and it is correct to do so).

We shouldn't break compat with well-behaving servers as a workaround
for buggy ones, so using quoted strings here is the best choice.