### PR TITLE
Patch 1

### DIFF
--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2597,11 +2597,11 @@ void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session,
 }
 
 LIBETPAN_EXPORT    
-void mailimap_set_163_workaround_enabled(mailimap * imap, int enabled) {
+void mailimap_set_163_workaround_enabled(mailimap * session, int enabled) {
 	imap->is_163_workaround_enabled = enabled;
 }
 
 LIBETPAN_EXPORT
-int mailimap_is_163_workaround_enabled(mailimap * imap) {
+int mailimap_is_163_workaround_enabled(mailimap * session) {
 	return imap->is_163_workaround_enabled;
 }

--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2590,3 +2590,13 @@ void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session,
   session->imap_logger = logger;
   session->imap_logger_context = logger_context;
 }
+
+LIBETPAN_EXPORT    
+void mailimap_set_complex_command_tag_enabled(mailimap * imap, int enabled) {
+	imap->complex_command_tag_enabled = enabled;
+}
+
+LIBETPAN_EXPORT
+int mailimap_is_complex_command_tag_enabled(mailimap * imap) {
+	return imap->complex_command_tag_enabled;
+}

--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2309,7 +2309,12 @@ int mailimap_send_current_tag(mailimap * session)
   int r;
   
   session->imap_tag ++;
-  snprintf(tag_str, 15, "C%i", session->imap_tag);
+  
+  if(mailimap_is_163_workaround_enabled(session))
+    snprintf(tag_str, 15, "C%i", session->imap_tag);
+  else
+    snprintf(tag_str, 15, "%i", session->imap_tag);	
+  
 
   r = mailimap_tag_send(session->imap_stream, tag_str);
   if (r != MAILIMAP_NO_ERROR)
@@ -2502,7 +2507,7 @@ mailimap * mailimap_new(size_t imap_progr_rate,
 
   f->imap_logger = NULL;
   f->imap_logger_context = NULL;
-  f->complex_command_tag_enabled = 0
+  f->is_163_workaround_enabled = 0;
   return f;
   
  free_stream_buffer:
@@ -2592,11 +2597,11 @@ void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session,
 }
 
 LIBETPAN_EXPORT    
-void mailimap_set_complex_command_tag_enabled(mailimap * imap, int enabled) {
-	imap->complex_command_tag_enabled = enabled;
+void mailimap_set_163_workaround_enabled(mailimap * imap, int enabled) {
+	imap->is_163_workaround_enabled = enabled;
 }
 
 LIBETPAN_EXPORT
-int mailimap_is_complex_command_tag_enabled(mailimap * imap) {
-	return imap->complex_command_tag_enabled;
+int mailimap_is_163_workaround_enabled(mailimap * imap) {
+	return imap->is_163_workaround_enabled;
 }

--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2309,7 +2309,7 @@ int mailimap_send_current_tag(mailimap * session)
   int r;
   
   session->imap_tag ++;
-  snprintf(tag_str, 15, "X%i", session->imap_tag);
+  snprintf(tag_str, 15, "C%i", session->imap_tag);
 
   r = mailimap_tag_send(session->imap_stream, tag_str);
   if (r != MAILIMAP_NO_ERROR)

--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2502,7 +2502,7 @@ mailimap * mailimap_new(size_t imap_progr_rate,
 
   f->imap_logger = NULL;
   f->imap_logger_context = NULL;
-
+  f->complex_command_tag_enabled = 0
   return f;
   
  free_stream_buffer:

--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2309,7 +2309,7 @@ int mailimap_send_current_tag(mailimap * session)
   int r;
   
   session->imap_tag ++;
-  snprintf(tag_str, 15, "%i", session->imap_tag);
+  snprintf(tag_str, 15, "X%i", session->imap_tag);
 
   r = mailimap_tag_send(session->imap_stream, tag_str);
   if (r != MAILIMAP_NO_ERROR)

--- a/src/low-level/imap/mailimap.c
+++ b/src/low-level/imap/mailimap.c
@@ -2598,10 +2598,10 @@ void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session,
 
 LIBETPAN_EXPORT    
 void mailimap_set_163_workaround_enabled(mailimap * session, int enabled) {
-	imap->is_163_workaround_enabled = enabled;
+	session->is_163_workaround_enabled = enabled;
 }
 
 LIBETPAN_EXPORT
 int mailimap_is_163_workaround_enabled(mailimap * session) {
-	return imap->is_163_workaround_enabled;
+	return session->is_163_workaround_enabled;
 }

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -802,7 +802,16 @@ time_t mailimap_get_timeout(mailimap * session);
 LIBETPAN_EXPORT
 void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session, int log_type,
     const char * str, size_t size, void * context), void * logger_context);
+    
+LIBETPAN_EXPORT    
+void mailimap_set_complex_command_tag_enabled(mailimap * imap, int enabled); 
 
+LIBETPAN_EXPORT
+int mailimap_is_complex_command_tag_enabled(mailimap * imap); 
+
+ #ifdef __cplusplus
+ }
+ #endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -804,10 +804,10 @@ void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session,
     const char * str, size_t size, void * context), void * logger_context);
 
 LIBETPAN_EXPORT
-int mailimap_is_163_workaround_enabled(mailimap * imap);
+int mailimap_is_163_workaround_enabled(mailimap * session);
     
 LIBETPAN_EXPORT    
-void mailimap_set_163_workaround_enabled(mailimap * imap, int enabled);
+void mailimap_set_163_workaround_enabled(mailimap * session, int enabled);
 
 #ifdef __cplusplus
 }

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -809,9 +809,6 @@ void mailimap_set_complex_command_tag_enabled(mailimap * imap, int enabled);
 LIBETPAN_EXPORT
 int mailimap_is_complex_command_tag_enabled(mailimap * imap); 
 
- #ifdef __cplusplus
- }
- #endif
 #ifdef __cplusplus
 }
 #endif

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -802,12 +802,12 @@ time_t mailimap_get_timeout(mailimap * session);
 LIBETPAN_EXPORT
 void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session, int log_type,
     const char * str, size_t size, void * context), void * logger_context);
-    
-LIBETPAN_EXPORT    
-void mailimap_set_complex_command_tag_enabled(mailimap * imap, int enabled); 
 
 LIBETPAN_EXPORT
-int mailimap_is_complex_command_tag_enabled(mailimap * imap); 
+int mailimap_is_163_workaround_enabled(mailimap * imap);
+    
+LIBETPAN_EXPORT    
+void mailimap_set_163_workaround_enabled(mailimap * imap, int enabled);
 
 #ifdef __cplusplus
 }

--- a/src/low-level/imap/mailimap_types.h
+++ b/src/low-level/imap/mailimap_types.h
@@ -3385,6 +3385,8 @@ struct mailimap {
   
   void (* imap_logger)(mailimap * session, int log_type, const char * str, size_t size, void * context);
   void * imap_logger_context;
+  
+  int complex_command_tag_enabled;
 };
 
 

--- a/src/low-level/imap/mailimap_types.h
+++ b/src/low-level/imap/mailimap_types.h
@@ -3386,7 +3386,7 @@ struct mailimap {
   void (* imap_logger)(mailimap * session, int log_type, const char * str, size_t size, void * context);
   void * imap_logger_context;
   
-  int complex_command_tag_enabled;
+  int is_163_workaround_enabled;
 };
 
 


### PR DESCRIPTION
163 mail server will reject the command which with a number tag.
eg.
`
1 CAPABILITY
`
`
2 LOGIN USERNAME PASSWORD
`
`
3 CAPABILITY
`
`
4 LIST "" ""
`
`
5 ID NIL
`
`
6 SELECT INBOX
`
this command sequence above, will be reject at the last line by 163.com mail server, the  response is:
6 NO SELECT The login is not safe! Please update your mail client: http://mail.163.com/dashi

if the command tag with some prefix character.this issue will be solved.