### PR TITLE
Added macro LIBETPAN_HAS_MAILIMAP_163_WORKAROUND

### DIFF
--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -803,6 +803,10 @@ LIBETPAN_EXPORT
 void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session, int log_type,
     const char * str, size_t size, void * context), void * logger_context);
 
+#ifndef ENABLE_163_WORKAROUND
+  #define ENABLE_163_WORKAROUND
+#endif
+
 LIBETPAN_EXPORT
 int mailimap_is_163_workaround_enabled(mailimap * session);
     

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -804,7 +804,7 @@ void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session,
     const char * str, size_t size, void * context), void * logger_context);
 
 #ifndef ENABLE_163_WORKAROUND
-  #define ENABLE_163_WORKAROUND
+  #define ENABLE_163_WORKAROUND	1
 #endif
 
 LIBETPAN_EXPORT

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -803,8 +803,8 @@ LIBETPAN_EXPORT
 void mailimap_set_logger(mailimap * session, void (* logger)(mailimap * session, int log_type,
     const char * str, size_t size, void * context), void * logger_context);
 
-#ifndef ENABLE_163_WORKAROUND
-  #define ENABLE_163_WORKAROUND	1
+#ifndef LIBETPAN_HAS_MAILIMAP_163_WORKAROUND
+  #define LIBETPAN_HAS_MAILIMAP_163_WORKAROUND	1
 #endif
 
 LIBETPAN_EXPORT


### PR DESCRIPTION
I have added this feature (references #192 ) into the mailcore2,  the compiler will ignore this feature when someone compile the new version of mailcore2 without this patch and this macro definition.