### PR TITLE
Add NTLM Support!

### DIFF
--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1360,7 +1360,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
-            
+        
         if(strlen(auth_type) == 4 && strcmp(auth_type, "NTLM", 4) == 0) {
           if(r != SASL_OK) {
             r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1378,6 +1378,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         
           r = sasl_client_step(session->smtp_sasl.sasl_conn,
             decoded, decoded_len, NULL, &sasl_out, &sasl_out_len);
+          free(decoded);
         }
         
         if ((r != SASL_CONTINUE) && (r != SASL_OK)) {

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1350,7 +1350,6 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
           * p = '\0';
         }
         
-        
         response_len = strlen(session->response);
         max_decoded = response_len * 3 / 4;
         decoded = malloc(max_decoded + 1);
@@ -1358,7 +1357,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
           res = MAILSMTP_ERROR_MEMORY;
           goto free_sasl_conn;
         }
-	
+        
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
         if(strlen(auth_type) == 4 && strcmp(auth_type, "NTLM", 4) == 0) {

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1361,7 +1361,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
         
-        if(strlen(auth_type) == 4 && strcmp(auth_type, "NTLM", 4) == 0) {
+        if(strcmp(auth_type, "NTLM") == 0) {
           if(r != SASL_OK) {
             r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);
           } else {

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1339,7 +1339,6 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         char * decoded;
         unsigned int decoded_len;
         unsigned int max_decoded;
-        unsigned int max_auth_type;
         char * p;
         
         p = strchr(session->response, '\r');
@@ -1360,10 +1359,9 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
           goto free_sasl_conn;
         }
 	
-	max_auth_type = strlen(auth_type) < 4 ? strlen(auth_type) : 4;
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
-        if(strncasecmp(auth_type, "NTLM", max_auth_type) == 0) {
+        if(strlen(auth_type) == 4 && strncasecmp(auth_type, "NTLM", 4) == 0) {
           if(r != SASL_OK) {
             r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);
           } else {

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1350,7 +1350,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
           * p = '\0';
         }
         
-        response_len = strlen(session->response);
+        response_len = (unsigned int) strlen(session->response);
         max_decoded = response_len * 3 / 4;
         decoded = malloc(max_decoded + 1);
         if (decoded == NULL) {
@@ -1360,6 +1360,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
+            
         if(strlen(auth_type) == 4 && strcmp(auth_type, "NTLM", 4) == 0) {
           if(r != SASL_OK) {
             r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -939,6 +939,10 @@ int mailsmtp_auth_type(mailsmtp * session,
   case MAILSMTP_AUTH_DIGEST_MD5:
     return mailesmtp_auth_sasl(session, "DIGEST-MD5",
         hostname, NULL, NULL, user, user, pass, NULL);
+        
+  case MAILSMTP_AUTH_NTLM:
+    return mailesmtp_auth_sasl(session, "NTLM",
+        hostname, NULL, NULL, user, user, pass, NULL);
     
   default:
     return MAILSMTP_ERROR_NOT_IMPLEMENTED;
@@ -1347,26 +1351,30 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         }
         
         response_len = (unsigned int) strlen(session->response);
-        max_decoded = response_len * 3 / 4;
-        decoded = malloc(max_decoded + 1);
-        if (decoded == NULL) {
-          res = MAILSMTP_ERROR_MEMORY;
-          goto free_sasl_conn;
-        }
+        if(strncasecmp(auth_type, "NTLM", strlen(auth_type)) == 0) {
+          r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);
+        } else {
+          max_decoded = response_len * 3 / 4;
+          decoded = malloc(max_decoded + 1);
+          if (decoded == NULL) {
+            res = MAILSMTP_ERROR_MEMORY;
+            goto free_sasl_conn;
+          }
         
-        r = sasl_decode64(session->response, response_len,
+          r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
         
-        if (r != SASL_OK) {
-          free(decoded);
-          res = MAILSMTP_ERROR_MEMORY;
-          goto free_sasl_conn;
-        }
+          if (r != SASL_OK) {
+            free(decoded);
+            res = MAILSMTP_ERROR_MEMORY;
+            goto free_sasl_conn;
+          }
         
-        r = sasl_client_step(session->smtp_sasl.sasl_conn,
+          r = sasl_client_step(session->smtp_sasl.sasl_conn,
             decoded, decoded_len, NULL, &sasl_out, &sasl_out_len);
         
-        free(decoded);
+          free(decoded);
+        }
         
         if ((r != SASL_CONTINUE) && (r != SASL_OK)) {
           res = MAILSMTP_ERROR_AUTH_LOGIN;

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1361,7 +1361,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
 	
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
-        if(strlen(auth_type) == 4 && strncasecmp(auth_type, "NTLM", 4) == 0) {
+        if(strlen(auth_type) == 4 && strcmp(auth_type, "NTLM", 4) == 0) {
           if(r != SASL_OK) {
             r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);
           } else {

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1339,6 +1339,7 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
         char * decoded;
         unsigned int decoded_len;
         unsigned int max_decoded;
+        unsigned int max_auth_type;
         char * p;
         
         p = strchr(session->response, '\r');
@@ -1358,10 +1359,11 @@ int mailesmtp_auth_sasl(mailsmtp * session, const char * auth_type,
           res = MAILSMTP_ERROR_MEMORY;
           goto free_sasl_conn;
         }
-
+	
+	max_auth_type = strlen(auth_type) < 4 ? strlen(auth_type) : 4;
         r = sasl_decode64(session->response, response_len,
             decoded, max_decoded + 1, &decoded_len);
-        if(strncasecmp(auth_type, "NTLM", strlen(auth_type)) == 0) {
+        if(strncasecmp(auth_type, "NTLM", max_auth_type) == 0) {
           if(r != SASL_OK) {
             r = sasl_client_step(session->smtp_sasl.sasl_conn, session->response, (unsigned) response_len, NULL, &sasl_out, &sasl_out_len);
           } else {


### PR DESCRIPTION
NTLM Response is plain text, so we do not need to decoded it.

##The workflow about NTLM:
After client sent "AUTH NTLM" to server, The Exchange server 2010 will respond plain text "443 NTLM supported.", Actually The Exchange server 2003 just respond "443" without body.

Client-------------------------->Server
AUTH NTLM----------------->
<---------------------------------443 NTLM Supported (plain text)
NTLMSSP....----------------->
<---------------------------------443 NTLMSSP........ (base64)
BOB_MESSAGE------------>
<---------------------------------235 Authentication successfully. (plain text)

[Click here to view more details about NTLM] (https://msdn.microsoft.com/en-us/library/cc246870.aspx)