### PR TITLE
To resolve a phase parsing problem when display name in "From", "To" or ...

### DIFF
--- a/src/low-level/imf/mailimf.c
+++ b/src/low-level/imf/mailimf.c
@@ -3080,7 +3080,11 @@ display-name    =       phrase
 static int mailimf_display_name_parse(const char * message, size_t length,
 				      size_t * indx, char ** result)
 {
-  return mailimf_phrase_parse(message, length, indx, result);
+  int r = mailimf_phrase_parse(message, length, indx, result);
+  if (message[*indx] == '\"') {
+    (*indx)++;
+  }
+  return r;  
 }
 
 /*


### PR DESCRIPTION
Some emails from 163.com contain very long display name in their "From" field. Just like <pre>From: "=?UTF-8?B?5ZOO5ZGA5oiR5Y676IGU57O75Lq65ZCN5a2X6L+Y6IO96L+Z5LmI6ZW/5ZGi?= =?UTF-8?B?5ZOO5ZGA5oiR5Y676IGU57O75Lq65ZCN5a2X6L+Y6IO96L+Z5LmI6ZW/5ZGi?=" \<xxx@163.com\> </pre>
And when LiBetPan resolves address like above, the second quote mark will not be cut. This causes a parsing failure. And as result, "null" will be returned.