### PR TITLE
Fix build for Xcode 7.0 beta 5.

### DIFF
--- a/build-mac/dependencies/prepare-cyrus-sasl.sh
+++ b/build-mac/dependencies/prepare-cyrus-sasl.sh
@@ -111,14 +111,15 @@ LIB_NAME=$ARCHIVE
 TARGETS="iPhoneOS iPhoneSimulator"
 
 SDK_IOS_MIN_VERSION=7.0
-SDK_IOS_VERSION="`xcodebuild -version -sdk 2>/dev/null | egrep SDKVersion | tail -n 1 | sed -E -n -e 's|SDKVersion: *(.*) *$|\1|p'`"
+SDK_IOS_VERSION="$(xcodebuild -version -sdk 'iphoneos' 2>/dev/null | egrep '^SDKVersion: ' | cut -d" " -f 2 | sort -n | tail -n1)"
 BUILD_DIR="$tmpdir/build"
 INSTALL_PATH="${BUILD_DIR}/${LIB_NAME}/universal"
 
 for TARGET in $TARGETS; do
 
     DEVELOPER="$(xcode-select --print-path)"
-    SYSROOT="`xcodebuild -version -sdk 2>/dev/null | egrep $TARGET -B 3 | egrep '^Path: '| egrep $SDK_IOS_VERSION | sort -u | tail -n 1| cut -d ' ' -f 2`"
+    SDK_ID="$(echo "$TARGET$SDK_IOS_VERSION" | tr A-Z a-z)"
+    SYSROOT="$(xcodebuild -version -sdk "$SDK_ID" 2>/dev/null | egrep '^Path: ' | cut -d ' ' -f 2)"
 
     case $TARGET in
         (iPhoneOS) 


### PR DESCRIPTION
This beta has added (or at least rearranged) the SDKs to include
WatchOS.  This results in SDK_IOS_VERSION finding the WatchOS version
number (2.0) instead of the iOS SDK version number.

Fix this by rewriting the lines that handle xcodebuild to use
different logic that is more robust.

Tested on Xcode 6.4 and Xcode 7.0 beta 5.