### PR TITLE
Improvement to support wrong MIME encoding which breaks a character into 2 lines

### DIFF
--- a/src/low-level/mime/mailmime_decode.c
+++ b/src/low-level/mime/mailmime_decode.c
@@ -494,6 +494,7 @@ int mailmime_encoded_word_parse(const char * message, size_t length,
       break;
     }
     
+    // Have padding (for base64), if append the next word to the current body, it won't be able to be correctly decoded
     if ((has_padding && encoding == MAILMIME_ENCODING_B) || cur_token == length) {
       break;
     }
@@ -534,6 +535,7 @@ int mailmime_encoded_word_parse(const char * message, size_t length,
       mailmime_charset_free(lookfwd_charset);
       cur_token = lookfwd_cur_token;
     } else {
+      // the next charset is not matched with the current one, free lookfwd_charset then break to decode the body appended so far
     free_lookfwd_charset:
       mailmime_charset_free(lookfwd_charset);
       break;


### PR DESCRIPTION
This improvement adds look forward logic to mailmime_encoded_word_parse to support wrong MIME encoding which breaks a character into 2 lines.

Example [from https://github.com/dinhviethoa/libetpan/issues/173#issuecomment-72502320]:
=?UTF-8?B?4Lij4Liw4LmA4Lia4Li04LiU4LiE4Lin4Liy4Lih4Lih4Lix4LiZ4Liq4LmM?=
=?UTF-8?B?4LmA4LiV4LmH4Lih4Lie4Li04LiB4Lix4LiUIFRSQU5TRk9STUVSUyA0IOC4?=
=?UTF-8?B?oeC4seC4meC4quC5jOC4hOC4o+C4muC4l+C4uOC4geC4o+C4sOC4muC4miDg?=
=?UTF-8?B?uJfguLXguYjguYDguJTguLXguKLguKfguYPguJnguYDguKHguLfguK3guIfg?=
=?UTF-8?B?uYTguJfguKI=?=

Expected result:
ระเบิดความมันส์เต็มพิกัด TRANSFORMERS 4 มันส์ครบทุกระบบ ที่เดียวในเมืองไทย
libetpan result:
ระเบิดความมันส์เต็มพิกัด TRANSFORMERS 4 ?ันส์ครบทุกระบบ ??ี่เดียวในเมือง??ทย