### PR TITLE
support Xcode 3.2.5 and Mac OS X 10.6

### DIFF
--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -1000,8 +1000,8 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         CFRelease(secTrust);
     }
     // This is work around for Mac OS X 10.6.
-//    if(!secTrust || count == 0)  {
-    else {
+    if(!secTrust || count == 0)  {
+//    else {
         certs = CFReadStreamCopyProperty(cfstream_data->readStream, kCFStreamPropertySSLPeerCertificates);
         if (certs) {
             count = CFArrayGetCount(certs);

--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -996,13 +996,16 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         // SecTrustEvaluate() needs to be called before SecTrustGetCertificateCount() in Mac OS X <= 10.8
         SecTrustEvaluate(secTrust, NULL);
         count = SecTrustGetCertificateCount(secTrust);
+        fprintf(stderr, "CFReadStreamCopyProperty kCFStreamPropertySSLPeerTrust %d\n", count);
         CFRelease(secTrust);
     }
     // This is work around for Mac OS X 10.6.
-    if(!secTrust || count == 0)  {
+//    if(!secTrust || count == 0)  {
+    else {
         certs = CFReadStreamCopyProperty(cfstream_data->readStream, kCFStreamPropertySSLPeerCertificates);
         if (certs) {
             count = CFArrayGetCount(certs);
+            fprintf(stderr, "CFReadStreamCopyProperty kCFStreamPropertySSLPeerCertificates %d\n", count);
             CFRelease(certs);
         }
         else {

--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -34,11 +34,13 @@
 #if HAVE_CFNETWORK
 #include <CoreFoundation/CoreFoundation.h>
 #include <TargetConditionals.h>
-#include <Security/SecTrust.h>
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 #include <CFNetwork/CFNetwork.h>
 #include <Security/Security.h>
 #else
+#if __MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_6
+#include <Security/Security.h>
+#endif
 #include <CoreServices/CoreServices.h>
 #endif
 #endif

--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -996,7 +996,7 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         // SecTrustEvaluate() needs to be called before SecTrustGetCertificateCount() in Mac OS X <= 10.8
         SecTrustEvaluate(secTrust, NULL);
         count = SecTrustGetCertificateCount(secTrust);
-        fprintf(stderr, "CFReadStreamCopyProperty kCFStreamPropertySSLPeerTrust %d\n", count);
+        // fprintf(stderr, "CFReadStreamCopyProperty kCFStreamPropertySSLPeerTrust %d\n", count);
         CFRelease(secTrust);
     }
     // This is work around for Mac OS X 10.6.
@@ -1005,7 +1005,7 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         certs = CFReadStreamCopyProperty(cfstream_data->readStream, kCFStreamPropertySSLPeerCertificates);
         if (certs) {
             count = CFArrayGetCount(certs);
-            fprintf(stderr, "CFReadStreamCopyProperty kCFStreamPropertySSLPeerCertificates %d\n", count);
+            // fprintf(stderr, "CFReadStreamCopyProperty kCFStreamPropertySSLPeerCertificates %d\n", count);
             CFRelease(certs);
         }
         else {

--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -34,6 +34,7 @@
 #if HAVE_CFNETWORK
 #include <CoreFoundation/CoreFoundation.h>
 #include <TargetConditionals.h>
+#include <Security/SecTrust.h>
 #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
 #include <CFNetwork/CFNetwork.h>
 #include <Security/Security.h>
@@ -995,7 +996,8 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         count = SecTrustGetCertificateCount(secTrust);
         CFRelease(secTrust);
     }
-    else {
+    // This is work around for Mac OS X 10.6.
+    if(!secTrust || count == 0)  {
         certs = CFReadStreamCopyProperty(cfstream_data->readStream, kCFStreamPropertySSLPeerCertificates);
         if (certs) {
             count = CFArrayGetCount(certs);


### PR DESCRIPTION
I compile libetpan with Xcode 3.2.5 on Mac OS X 10.6.8. I add header becase of SecTrustRef not define error. And I make work around connection problem issue on Mac OS X 10.6.8. CFReadStreamCopyProperty return 0 array not null on Mac OS X 10.6.8. I checked on imap-sample.c. This is very sensitive modify. Do you think this ?

Regards.