### PR TITLE
Added workaround for XLIST on cyon.ch

### DIFF
--- a/src/low-level/imap/xlist.c
+++ b/src/low-level/imap/xlist.c
@@ -151,8 +151,15 @@ int mailimap_xlist(mailimap * session, const char * mb,
     ext_data->ext_data = NULL;
   }
   
-  * result = result_list;
+  if (clist_isempty(result_list) && !clist_isempty(session->imap_response_info->rsp_mailbox_list)) {
+    // workaround, if server makes LIST-like response, example: cyon.ch
+    clist_free(result_list);
+    result_list = session->imap_response_info->rsp_mailbox_list;
+    session->imap_response_info->rsp_mailbox_list = NULL;
+  }
   
+  * result = result_list;
+
   error_code = response->rsp_resp_done->rsp_data.rsp_tagged->rsp_cond_state->rsp_type;
   
   mailimap_response_free(response);


### PR DESCRIPTION
I found a server with a buggy XLIST implementation.
It is cyon.ch.

It makes LIST-like response for XLIST request. Example:

```
9 XLIST "INBOX." "*"
* LIST (\HasNoChildren \Drafts) "." INBOX.Drafts
* LIST (\HasNoChildren \Sent) "." INBOX.Sent
* LIST (\HasNoChildren \Trash) "." INBOX.Trash
* LIST (\HasNoChildren \Junk) "." INBOX.Junk
* LIST (\HasNoChildren) "." "INBOX.Apple Mail To Do"
* LIST (\HasChildren) "." INBOX.Archiv
* LIST (\HasNoChildren) "." INBOX.Archiv.Archive_1M
* LIST (\HasNoChildren) "." INBOX.Archiv.Archive_1W
* LIST (\HasNoChildren) "." INBOX.Archiv.Archive_1Y
* LIST (\HasNoChildren) "." INBOX.Archiv.Archive_3M
* LIST (\HasNoChildren) "." INBOX.Archiv.Archive_6M
* LIST (\HasNoChildren) "." INBOX.Archiv.WI2
* LIST (\HasNoChildren) "." "INBOX.Deleted Messages"
* LIST (\HasChildren) "." INBOX.Div
* LIST (\HasNoChildren) "." INBOX.Div.AXA
* LIST (\HasNoChildren) "." INBOX.Div.Fotoklub_Duebendorf
* LIST (\HasNoChildren) "." INBOX.Div.Hochzeit
* LIST (\HasNoChildren) "." INBOX.Div.Homegate
* LIST (\HasNoChildren) "." INBOX.Div.PARSHIP
* LIST (\HasChildren) "." INBOX.Div.People
* LIST (\HasNoChildren) "." INBOX.Div.People.Carla
* LIST (\HasNoChildren) "." "INBOX.Div.People.Ma Pa"
* LIST (\HasNoChildren) "." INBOX.Div.People.sb
* LIST (\HasNoChildren) "." INBOX.Div.People.Yasmin
* LIST (\HasNoChildren) "." INBOX.Div.Privat
* LIST (\HasNoChildren) "." INBOX.Div.SHG
* LIST (\HasNoChildren) "." "INBOX.Div.SKDZ Fotolehrgang"
* LIST (\HasNoChildren) "." INBOX.Notes
* LIST (\HasNoChildren) "." INBOX.@SaneBlackHole
* LIST (\HasNoChildren) "." INBOX.@SaneBulk
* LIST (\HasNoChildren) "." INBOX.@SaneLater
* LIST (\HasNoChildren) "." INBOX.@SaneNews
* LIST (\HasNoChildren) "." INBOX.@SaneNextMonth
* LIST (\HasNoChildren) "." INBOX.@SaneNextWeek
* LIST (\HasNoChildren) "." INBOX.@SaneReminders
* LIST (\HasNoChildren \Sent) "." "INBOX.Sent Messages"
* LIST (\HasNoChildren \Archive) "." INBOX.Archive
9 OK List completed.
10 LIST "" "INBOX"
* LIST (\HasChildren) "." INBOX
10 OK List completed.
```

What do you think about my workaround for the issue?