### PR TITLE
Remove some warnings shown by GCC on Linux

### DIFF
--- a/src/data-types/mailstream_cancel.c
+++ b/src/data-types/mailstream_cancel.c
@@ -161,9 +161,6 @@ void mailstream_cancel_notify(struct mailstream_cancel * cancel)
 {
   char ch;
   struct mailstream_cancel_internal * ms_internal;
-#ifndef WIN32
-  int r;
-#endif
   
   ms_internal = cancel->ms_internal;
   MUTEX_LOCK(&ms_internal->ms_lock);
@@ -174,7 +171,7 @@ void mailstream_cancel_notify(struct mailstream_cancel * cancel)
   
   ch = 0;
 #ifndef WIN32
-  r = (int) write(cancel->ms_fds[1], &ch, 1);
+  write(cancel->ms_fds[1], &ch, 1);
 #else
   SetEvent(ms_internal->event);
 #endif
@@ -184,8 +181,7 @@ void mailstream_cancel_ack(struct mailstream_cancel * cancel)
 {
 #ifndef WIN32
   char ch;
-  int r;
-  r = (int) read(cancel->ms_fds[0], &ch, 1);
+  read(cancel->ms_fds[0], &ch, 1);
 #endif
 }
 

--- a/src/data-types/mailstream_cancel.c
+++ b/src/data-types/mailstream_cancel.c
@@ -204,12 +204,13 @@ int mailstream_cancel_cancelled(struct mailstream_cancel * cancel)
 
 int mailstream_cancel_get_fd(struct mailstream_cancel * cancel)
 {
-  struct mailstream_cancel_internal * ms_internal;
-  
-  ms_internal = cancel->ms_internal;
 #ifndef WIN32
   return cancel->ms_fds[0];
 #else
+  struct mailstream_cancel_internal * ms_internal;
+  
+  ms_internal = cancel->ms_internal;
+
   return ms_internal->event;
 #endif
 }

--- a/src/data-types/mailstream_compress.h
+++ b/src/data-types/mailstream_compress.h
@@ -66,4 +66,7 @@ LIBETPAN_EXPORT
 int mailstream_low_compress_interrupt_idle(mailstream_low * low);
 */
   
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/data-types/mailstream_helper.c
+++ b/src/data-types/mailstream_helper.c
@@ -493,14 +493,9 @@ int mailstream_send_data_with_context(mailstream * s, const char * message,
 static inline ssize_t get_data_size(const char * line, size_t length,
     size_t * result)
 {
-  int fix_eol;
-  const char * start;
   size_t count;
   size_t fixed_count;
   
-  start = line;
-
-  fix_eol = 0;
   count = 0;
   fixed_count = 0;
   
@@ -515,7 +510,6 @@ static inline ssize_t get_data_size(const char * line, size_t length,
       length --;
 
       if (length == 0) {
-        fix_eol = 1;
         fixed_count ++;
         break;
       }
@@ -529,7 +523,6 @@ static inline ssize_t get_data_size(const char * line, size_t length,
 	break;
       }
       else {
-        fix_eol = 1;
         fixed_count ++;
         break;
       }
@@ -540,7 +533,6 @@ static inline ssize_t get_data_size(const char * line, size_t length,
       count ++;
       length --;
 
-      fix_eol = 1;
       fixed_count ++;
       break;
     }
@@ -559,12 +551,10 @@ size_t mailstream_get_data_crlf_size(const char * message, size_t size)
 {
   const char * current;
   size_t count;
-  size_t last;
   size_t remaining;
   size_t fixed_count;
   
   count = 0;
-  last = 0;
   fixed_count = 0;
   
   current = message;

--- a/src/data-types/mailstream_low.c
+++ b/src/data-types/mailstream_low.c
@@ -96,9 +96,8 @@ static inline void mailstream_logger_internal(mailstream_low * s, int is_stream_
       f = fopen(LOG_FILE, "a"); \
       umask(old_mask); \
       if (f != NULL) { \
-        size_t nmemb; \
         maillock_write_lock(LOG_FILE, fileno(f)); \
-        nmemb = fwrite((buf), 1, (size), f); \
+        fwrite((buf), 1, (size), f); \
         maillock_write_unlock(LOG_FILE, fileno(f)); \
         fclose(f); \
       } \
@@ -123,9 +122,8 @@ static inline void mailstream_logger_internal(mailstream_low * s, int is_stream_
       f = fopen(LOG_FILE, "a"); \
       umask(old_mask); \
       if (f != NULL) { \
-        size_t nmemb; \
         maillock_write_lock(LOG_FILE, fileno(f)); \
-        nmemb = fwrite((buf), 1, (size), f); \
+        fwrite((buf), 1, (size), f); \
         maillock_write_unlock(LOG_FILE, fileno(f)); \
         fclose(f); \
       } \
@@ -150,9 +148,8 @@ static inline void mailstream_logger_internal(mailstream_low * s, int is_stream_
       f = fopen(LOG_FILE, "a"); \
       umask(old_mask); \
       if (f != NULL) { \
-        size_t nmemb; \
         maillock_write_lock(LOG_FILE, fileno(f)); \
-        nmemb = fputs((str), f); \
+        fputs((str), f); \
         maillock_write_unlock(LOG_FILE, fileno(f)); \
         fclose(f); \
       } \

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -774,7 +774,6 @@ static int wait_read(mailstream_low * s)
   int max_fd;
   int r;
   int cancelled;
-  int got_data;
 #ifdef WIN32
   HANDLE event;
 #endif
@@ -808,7 +807,6 @@ static int wait_read(mailstream_low * s)
 	}
   
   cancelled = (fds_read.fd_array[r - WAIT_OBJECT_0] == fd);
-  got_data = (fds_read.fd_array[r - WAIT_OBJECT_0] == event);
 	WSAEventSelect(ssl_data->fd, event, 0);
 	CloseHandle(event);
 #else
@@ -821,7 +819,6 @@ static int wait_read(mailstream_low * s)
     return -1;
   
   cancelled = (FD_ISSET(fd, &fds_read));
-  got_data = FD_ISSET(ssl_data->fd, &fds_read);
 #endif
   if (cancelled) {
     /* cancelled */

--- a/src/driver/implementation/db/dbdriver_message.c
+++ b/src/driver/implementation/db/dbdriver_message.c
@@ -204,10 +204,8 @@ static int initialize(mailmessage * msg_info)
 
 static void check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_session_data(msg_info)->db_flags_store,
+    mail_flags_store_set(get_session_data(msg_info)->db_flags_store,
         msg_info);
     /* ignore errors */
   }

--- a/src/driver/implementation/imap/imapdriver.c
+++ b/src/driver/implementation/imap/imapdriver.c
@@ -1119,9 +1119,7 @@ static int imapdriver_starttls(mailsession * session)
   clistiter * cur;
   int starttls;
   int capability_available;
-  struct imap_session_state_data * data;
   
-  data = get_data(session);
   imap = get_imap_session(session);
 
   capability_available = FALSE;

--- a/src/driver/implementation/imap/imapdriver_cached.c
+++ b/src/driver/implementation/imap/imapdriver_cached.c
@@ -656,10 +656,7 @@ static int imapdriver_cached_select_folder(mailsession * session, const char * m
   int r;
   char * quoted_mb;
   struct imap_cached_session_state_data * data;
-  mailsession * imap;
   char * old_mb;
-  
-  imap = get_ancestor(session);
   
   old_mb = get_ancestor_data(session)->imap_mailbox;
   if (old_mb != NULL)
@@ -868,7 +865,6 @@ static int boostrap_cache(mailsession * session)
 {
   struct mail_cache_db * cache_db;
   char filename[PATH_MAX];
-  mailimap * imap;
   struct imap_cached_session_state_data * data;
   MMAPString * mmapstr;
   int r;
@@ -878,7 +874,6 @@ static int boostrap_cache(mailsession * session)
   chash * keys_uid;
   
   data = get_cached_data(session);
-  imap = get_imap_session(session);
   
   if (data->imap_quoted_mb == NULL) {
     res = MAIL_ERROR_BAD_STATE;

--- a/src/driver/implementation/imap/imapdriver_message.c
+++ b/src/driver/implementation/imap/imapdriver_message.c
@@ -183,10 +183,8 @@ static void imap_flush(mailmessage * msg_info)
 
 static void imap_check(mailmessage * msg_info)
 {
-  int r;
-  
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_session_data(msg_info)->imap_flags_store,
+    mail_flags_store_set(get_session_data(msg_info)->imap_flags_store,
         msg_info);
     /* ignore errors */
   }

--- a/src/driver/implementation/imap/imapdriver_tools.c
+++ b/src/driver/implementation/imap/imapdriver_tools.c
@@ -370,14 +370,12 @@ imap_body_media_basic_to_content_type(struct mailimap_media_basic *
   int discrete_type_type;
   int composite_type_type;
   int mime_type_type;
-  char * subtype;
   int r;
   int res;
 
   discrete_type = NULL;
   composite_type = NULL;
   discrete_type_extension = NULL;
-  subtype = NULL;
   discrete_type_type = 0;
   composite_type_type = 0;
   mime_type_type = 0;
@@ -1650,11 +1648,9 @@ imap_mailbox_list_to_mailbox_list(clist * imap_mailbox_list,
   clist * list;
   struct mailimf_mailbox_list * mb_list;
   int r;
-  int res;
 
   list = clist_new();
   if (list == NULL) {
-    res = MAIL_ERROR_MEMORY;
     goto err;
   }
 
@@ -1670,21 +1666,18 @@ imap_mailbox_list_to_mailbox_list(clist * imap_mailbox_list,
 
     r = imap_address_to_mailbox(imap_addr, &mb);
     if (r != MAIL_NO_ERROR) {
-      res = r;
       goto free_list;
     }
     
     r = clist_append(list, mb);
     if (r != 0) {
       mailimf_mailbox_free(mb);
-      res = MAIL_ERROR_MEMORY;
       goto free_list;
     }
   }
 
   mb_list = mailimf_mailbox_list_new(list);
   if (mb_list == NULL) {
-    res = MAIL_ERROR_MEMORY;
     goto free_list;
   }
 
@@ -3692,7 +3685,6 @@ imapdriver_get_cached_envelope(struct mail_cache_db * cache_db,
 #if 0
   mailsession * imap_session;
 #endif
-  mailimap * imap;
   int r;
   struct mailimf_fields * fields;
   int res;
@@ -3700,10 +3692,8 @@ imapdriver_get_cached_envelope(struct mail_cache_db * cache_db,
   
 #if 0
   imap_session = cached_session_get_ancestor(session);
-  imap = ((struct imap_session_state_data *) (imap_session->data))->session;
+  ((struct imap_session_state_data *) (imap_session->data))->session;
 #endif
-  imap = cached_session_get_imap_session(session);
-
   generate_key_from_message(keyname, PATH_MAX,
 			    msg, MAILIMAP_MSG_ATT_ENVELOPE);
 

--- a/src/driver/implementation/imap/imapdriver_tools.c
+++ b/src/driver/implementation/imap/imapdriver_tools.c
@@ -3682,18 +3682,11 @@ imapdriver_get_cached_envelope(struct mail_cache_db * cache_db,
     mailsession * session, mailmessage * msg,
     struct mailimf_fields ** result)
 {
-#if 0
-  mailsession * imap_session;
-#endif
   int r;
   struct mailimf_fields * fields;
   int res;
   char keyname[PATH_MAX];
   
-#if 0
-  imap_session = cached_session_get_ancestor(session);
-  ((struct imap_session_state_data *) (imap_session->data))->session;
-#endif
   generate_key_from_message(keyname, PATH_MAX,
 			    msg, MAILIMAP_MSG_ATT_ENVELOPE);
 

--- a/src/driver/implementation/maildir/maildirdriver.c
+++ b/src/driver/implementation/maildir/maildirdriver.c
@@ -395,7 +395,6 @@ static int append_message_flags(mailsession * session,
   struct maildir * md;
   int r;
   char uid[PATH_MAX];
-  struct maildir_msg * md_msg;
   chashdatum key;
   chashdatum value;
   uint32_t md_flags;
@@ -417,8 +416,6 @@ static int append_message_flags(mailsession * session,
   r = chash_get(md->mdir_msg_hash, &key, &value);
   if (r < 0)
     goto exit;
-  
-  md_msg = value.data;
   
   md_flags = maildirdriver_flags_to_maildir_flags(flags->fl_flags);
   

--- a/src/driver/implementation/maildir/maildirdriver_cached.c
+++ b/src/driver/implementation/maildir/maildirdriver_cached.c
@@ -478,7 +478,6 @@ static int append_message_flags(mailsession * session,
   struct maildir * md;
   int r;
   char uid[PATH_MAX];
-  struct maildir_msg * md_msg;
   chashdatum key;
   chashdatum value;
   uint32_t md_flags;
@@ -527,8 +526,6 @@ static int append_message_flags(mailsession * session,
   r = chash_get(md->mdir_msg_hash, &key, &value);
   if (r < 0)
     goto exit;
-  
-  md_msg = value.data;
   
   md_flags = maildirdriver_flags_to_maildir_flags(flags->fl_flags);
   

--- a/src/driver/implementation/maildir/maildirdriver_cached_message.c
+++ b/src/driver/implementation/maildir/maildirdriver_cached_message.c
@@ -253,12 +253,10 @@ static int initialize(mailmessage * msg_info)
 
 static void check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_session_ancestor_data(msg_info)->md_flags_store, msg_info);
+    mail_flags_store_set(get_session_ancestor_data(msg_info)->md_flags_store, msg_info);
     
-    r = mail_flags_store_set(get_cached_session_data(msg_info)->md_flags_store, msg_info);
+    mail_flags_store_set(get_cached_session_data(msg_info)->md_flags_store, msg_info);
     /* ignore errors */
   }
 }

--- a/src/driver/implementation/maildir/maildirdriver_message.c
+++ b/src/driver/implementation/maildir/maildirdriver_message.c
@@ -205,10 +205,8 @@ static int initialize(mailmessage * msg_info)
 
 static void check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_session_data(msg_info)->md_flags_store,
+    mail_flags_store_set(get_session_data(msg_info)->md_flags_store,
         msg_info);
     /* ignore errors */
   }

--- a/src/driver/implementation/mbox/mboxdriver_cached_message.c
+++ b/src/driver/implementation/mbox/mboxdriver_cached_message.c
@@ -231,10 +231,8 @@ static void mbox_flush(mailmessage * msg_info)
 
 static void mbox_check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_cached_session_data(msg_info)->mbox_flags_store,
+    mail_flags_store_set(get_cached_session_data(msg_info)->mbox_flags_store,
         msg_info);
     /* ignore errors */
   }

--- a/src/driver/implementation/mh/mhdriver_cached.c
+++ b/src/driver/implementation/mh/mhdriver_cached.c
@@ -516,10 +516,9 @@ static int mhdriver_cached_connect_path(mailsession * session, const char * path
 
 static int mhdriver_cached_logout(mailsession * session)
 {
-  int r;
   struct mh_cached_session_state_data * cached_data;
 
-  r = write_max_uid_value(session);
+  write_max_uid_value(session);
 
   cached_data = get_cached_data(session);
 

--- a/src/driver/implementation/mh/mhdriver_cached_message.c
+++ b/src/driver/implementation/mh/mhdriver_cached_message.c
@@ -222,10 +222,8 @@ static void mh_flush(mailmessage * msg_info)
 
 static void mh_check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_cached_session_data(msg_info)->mh_flags_store,
+    mail_flags_store_set(get_cached_session_data(msg_info)->mh_flags_store,
         msg_info);
     /* ignore errors */
   }

--- a/src/driver/implementation/nntp/nntpdriver.c
+++ b/src/driver/implementation/nntp/nntpdriver.c
@@ -617,9 +617,6 @@ static int nntpdriver_append_message(mailsession * session,
 				     const char * message, size_t size)
 {
   int r;
-  struct nntp_session_state_data * data;
-
-  data = get_data(session);
 
   do {
     r = newsnntp_post(get_nntp_session(session), message, size);

--- a/src/driver/implementation/nntp/nntpdriver_cached_message.c
+++ b/src/driver/implementation/nntp/nntpdriver_cached_message.c
@@ -225,10 +225,8 @@ static void nntp_flush(mailmessage * msg_info)
 
 static void nntp_check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_cached_session_data(msg_info)->nntp_flags_store,
+    mail_flags_store_set(get_cached_session_data(msg_info)->nntp_flags_store,
         msg_info);
     /* ignore errors */
   }

--- a/src/driver/implementation/nntp/nntpstorage.c
+++ b/src/driver/implementation/nntp/nntpstorage.c
@@ -300,9 +300,7 @@ static int nntp_mailstorage_connect(struct mailstorage * storage)
 static int nntp_mailstorage_get_folder_session(struct mailstorage * storage,
     char * pathname, mailsession ** result)
 {
-  int r;
-  
-  r = mailsession_select_folder(storage->sto_session, pathname);
+  mailsession_select_folder(storage->sto_session, pathname);
   
   * result = storage->sto_session;
   

--- a/src/driver/implementation/pop3/pop3driver.c
+++ b/src/driver/implementation/pop3/pop3driver.c
@@ -208,9 +208,7 @@ static int pop3driver_starttls(mailsession * session)
 {
   int r;
   mailpop3 * pop3;
-  struct pop3_session_state_data * data;
 
-  data = get_data(session);
   pop3 = get_pop3_session(session);
 
   r = mailpop3_socket_starttls(pop3);

--- a/src/driver/implementation/pop3/pop3driver_cached_message.c
+++ b/src/driver/implementation/pop3/pop3driver_cached_message.c
@@ -229,10 +229,8 @@ static void pop3_flush(mailmessage * msg_info)
 
 static void pop3_check(mailmessage * msg_info)
 {
-  int r;
-
   if (msg_info->msg_flags != NULL) {
-    r = mail_flags_store_set(get_cached_session_data(msg_info)->pop3_flags_store,
+    mail_flags_store_set(get_cached_session_data(msg_info)->pop3_flags_store,
         msg_info);
   }
 }

--- a/src/driver/interface/mailmessage_tools.c
+++ b/src/driver/interface/mailmessage_tools.c
@@ -174,9 +174,7 @@ mailmessage_generic_prefetch_bodystructure(mailmessage * msg_info)
 void
 mailmessage_generic_fetch_result_free(mailmessage * msg_info, char * msg)
 {
-  int r;
-  
-  r = mmap_string_unref(msg);
+  mmap_string_unref(msg);
 }
 
 int mailmessage_generic_fetch(mailmessage * msg_info,
@@ -185,7 +183,6 @@ int mailmessage_generic_fetch(mailmessage * msg_info,
 {
   int r;
   char * message;
-  size_t cur_token;
   size_t length;
   MMAPString * mmapstr;
   int res;
@@ -200,7 +197,6 @@ int mailmessage_generic_fetch(mailmessage * msg_info,
 
   message = msg->msg_message;
   length = msg->msg_length;
-  cur_token = 0;
   
   mmapstr = mmap_string_new_len(message, length);
   if (mmapstr == NULL) {

--- a/src/driver/interface/mailstorage.c
+++ b/src/driver/interface/mailstorage.c
@@ -318,7 +318,6 @@ int mailstorage_connect(struct mailstorage * storage)
 LIBETPAN_EXPORT
 void mailstorage_disconnect(struct mailstorage * storage)
 {
-  int r;
   clistiter * cur;
 
   while ((cur = clist_begin(storage->sto_shared_folders)) != NULL) {
@@ -331,7 +330,7 @@ void mailstorage_disconnect(struct mailstorage * storage)
   if (storage->sto_session == NULL)
     return;
 
-  r = mailsession_logout(storage->sto_session);
+  mailsession_logout(storage->sto_session);
 
   mailsession_free(storage->sto_session);
   storage->sto_session = NULL;

--- a/src/driver/tools/mailthread.c
+++ b/src/driver/tools/mailthread.c
@@ -306,10 +306,6 @@ static char * extract_subject(char * default_from,
     */
 
     while (len > 0) {
-      int chg;
-
-      chg = FALSE;
-
       /* subj-trailer    = "(fwd)" / WSP */
       if (subj[len - 1] == ' ') {
 	subj[len - 1] = '\0';
@@ -373,14 +369,11 @@ static char * extract_subject(char * default_from,
     */
 
     if (len >= 5) {
-      size_t saved_begin;
-
-      saved_begin = begin;
       if (strncasecmp(subj + begin, "[fwd:", 5) == 0) {
 	begin += 5;
 	
 	if (subj[len - 1] != ']')
-	  saved_begin = begin;
+	  ;
 	else {
 	  tree->node_is_reply = TRUE;
 
@@ -1093,10 +1086,8 @@ mail_build_thread_references(char * default_from,
 	  "(fwd)" subj-trailer) and the current message is not.
 	*/
 	struct mailmessage_tree * msg_in_table;
-	unsigned int * iter_in_table;
 	int replace;
 
-	iter_in_table = data.data;
 	msg_in_table = carray_get(rootlist, cur);
 
 	replace = FALSE;

--- a/src/driver/tools/mailthread.c
+++ b/src/driver/tools/mailthread.c
@@ -368,19 +368,15 @@ static char * extract_subject(char * default_from,
       subj-fwd-hdr and subj-fwd-trl and repeat from step (2).
     */
 
-    if (len >= 5) {
-      if (strncasecmp(subj + begin, "[fwd:", 5) == 0) {
-	begin += 5;
-	
-	if (subj[len - 1] != ']')
-	  ;
-	else {
-	  tree->node_is_reply = TRUE;
+    if ((len >= 5) && (strncasecmp(subj + begin, "[fwd:", 5) == 0)) {
+      begin += 5;
 
-	  subj[len - 1] = '\0';
-	  len --;
-	  do_repeat_6 = TRUE;
-	}
+      if (subj[len - 1] == ']') {
+	tree->node_is_reply = TRUE;
+
+	subj[len - 1] = '\0';
+	len --;
+	do_repeat_6 = TRUE;
       }
     }
 

--- a/src/engine/mailengine.c
+++ b/src/engine/mailengine.c
@@ -596,11 +596,10 @@ static void folder_free_msg_list(struct folder_ref_info * ref_info,
   
   for(i = 0 ; i < carray_count(env_list->msg_tab) ; i ++) {
     mailmessage * msg;
-    int count;
     
     msg = carray_get(env_list->msg_tab, i);
     
-    count = folder_message_unref(ref_info, msg);
+    folder_message_unref(ref_info, msg);
   }
   carray_set_size(env_list->msg_tab, 0);
   mailmessage_list_free(env_list);
@@ -855,7 +854,6 @@ static int folder_connect(struct storage_ref_info * ref_info,
     struct mailfolder * folder)
 {
   int r;
-  struct folder_ref_info * folder_ref_info;
   
   r = do_storage_connect(ref_info);
   if (r != MAIL_NO_ERROR)
@@ -865,8 +863,6 @@ static int folder_connect(struct storage_ref_info * ref_info,
   if (r != MAIL_NO_ERROR)
     return r;
 
-  folder_ref_info = storage_get_folder_ref(ref_info, folder);
- 
   return MAIL_NO_ERROR;
 }
 

--- a/src/engine/mailprivacy_gnupg.c
+++ b/src/engine/mailprivacy_gnupg.c
@@ -2823,17 +2823,17 @@ static int mailprivacy_gnupg_init_lock_done = 0;
 #endif
 static chash * encryption_id_hash = NULL;
 
-static void mailprivacy_gnupg_init_lock(void)
-{
 #ifdef LIBETPAN_REENTRANT
 #if defined(HAVE_PTHREAD_H) && !defined(IGNORE_PTHREAD_H)
 #elif (defined WIN32)
+static void mailprivacy_gnupg_init_lock(void)
+{
   if (InterlockedExchange(&mailprivacy_gnupg_init_lock_done, 1) == 0){
     InitializeCriticalSection(&encryption_id_hash_lock);
   }
-#endif
-#endif
 }
+#endif
+#endif
 
 int mailprivacy_gnupg_init(struct mailprivacy * privacy)
 {

--- a/src/engine/mailprivacy_gnupg.c
+++ b/src/engine/mailprivacy_gnupg.c
@@ -411,7 +411,6 @@ static int pgp_decrypt(struct mailprivacy * privacy,
     goto err;
   }
   
-  clist_content(cur);
   cur = clist_next(cur);
   if (cur == NULL) {
     res = MAIL_ERROR_INVAL;

--- a/src/engine/mailprivacy_gnupg.c
+++ b/src/engine/mailprivacy_gnupg.c
@@ -389,7 +389,6 @@ static int pgp_decrypt(struct mailprivacy * privacy,
     mailmessage * msg,
     struct mailmime * mime, struct mailmime ** result)
 {
-  struct mailmime * version_mime;
   struct mailmime * encrypted_mime;
   clistiter * cur;
   char encrypted_filename[PATH_MAX];
@@ -412,7 +411,7 @@ static int pgp_decrypt(struct mailprivacy * privacy,
     goto err;
   }
   
-  version_mime = clist_content(cur);
+  clist_content(cur);
   cur = clist_next(cur);
   if (cur == NULL) {
     res = MAIL_ERROR_INVAL;
@@ -576,7 +575,6 @@ pgp_verify(struct mailprivacy * privacy,
   int r;
   clistiter * cur;
   char command[PATH_MAX];
-  int sign_ok;
   struct mailmime * description_mime;
   char decrypted_filename[PATH_MAX];
   char description_filename[PATH_MAX];
@@ -659,16 +657,13 @@ pgp_verify(struct mailprivacy * privacy,
   snprintf(command, sizeof(command), "gpg --batch --yes --verify '%s' '%s'",
       quoted_signature_filename, quoted_signed_filename);
 
-  sign_ok = 0;
   r = gpg_command_passphrase(privacy, msg, command, NULL,
       decrypted_filename, description_filename);
   switch (r) {
   case NO_ERROR_PGP:
-    sign_ok = 1;
     break;
   case ERROR_PGP_NOPASSPHRASE:
   case ERROR_PGP_CHECK:
-    sign_ok = 0;
     break;
   case ERROR_PGP_COMMAND:
     res = MAIL_ERROR_COMMAND;
@@ -763,7 +758,6 @@ static int pgp_verify_clearsigned(struct mailprivacy * privacy,
   int r;
   char command[PATH_MAX];
   int res;
-  int sign_ok;
   size_t written;
   char signed_filename[PATH_MAX];
   FILE * signed_f;
@@ -829,16 +823,13 @@ static int pgp_verify_clearsigned(struct mailprivacy * privacy,
   snprintf(command, sizeof(command),
       "gpg --batch --yes --decrypt '%s'", quoted_signed_filename);
   
-  sign_ok = 0;
   r = gpg_command_passphrase(privacy, msg, command, NULL,
       stripped_filename, description_filename);
   switch (r) {
   case NO_ERROR_PGP:
-    sign_ok = 1;
     break;
   case ERROR_PGP_NOPASSPHRASE:
   case ERROR_PGP_CHECK:
-    sign_ok = 0;
     break;
   case ERROR_PGP_COMMAND:
     res = MAIL_ERROR_COMMAND;
@@ -990,7 +981,6 @@ static int pgp_decrypt_armor(struct mailprivacy * privacy,
   struct mailmime * multipart;
   int r;
   int res;
-  int sign_ok;
   char quoted_encrypted_filename[PATH_MAX];
 
   if (mime->mm_parent == NULL) {
@@ -1052,16 +1042,13 @@ static int pgp_decrypt_armor(struct mailprivacy * privacy,
       "gpg --passphrase-fd=0 --batch --yes --decrypt '%s'",
       quoted_encrypted_filename);
   
-  sign_ok = 0;
   r = gpg_command_passphrase(privacy, msg, command, NULL,
       decrypted_filename, description_filename);
   switch (r) {
   case NO_ERROR_PGP:
-    sign_ok = 1;
     break;
   case ERROR_PGP_NOPASSPHRASE:
   case ERROR_PGP_CHECK:
-    sign_ok = 0;
     break;
   case ERROR_PGP_COMMAND:
     res = MAIL_ERROR_COMMAND;

--- a/src/engine/mailprivacy_smime.c
+++ b/src/engine/mailprivacy_smime.c
@@ -1527,7 +1527,6 @@ static int get_cert_from_sig(struct mailprivacy * privacy,
     struct mailmime * mime)
 {
   clistiter * cur;
-  struct mailmime * signed_mime;
   struct mailmime * signature_mime;
   int res;
   char signature_filename[PATH_MAX];
@@ -1561,7 +1560,6 @@ static int get_cert_from_sig(struct mailprivacy * privacy,
     goto err;
   }
   
-  signed_mime = cur->data;
   cur = clist_next(cur);
   if (cur == NULL) {
     res = MAIL_ERROR_INVAL;

--- a/src/engine/mailprivacy_tools.c
+++ b/src/engine/mailprivacy_tools.c
@@ -507,7 +507,6 @@ mailprivacy_new_file_part(struct mailprivacy * privacy,
     char * default_content_type, int default_encoding)
 {
   char basename_buf[PATH_MAX];
-  char * name;
   struct mailmime_mechanism * encoding;
   struct mailmime_content * content;
   struct mailmime * mime;
@@ -520,10 +519,7 @@ mailprivacy_new_file_part(struct mailprivacy * privacy,
   
   if (filename != NULL) {
     strncpy(basename_buf, filename, PATH_MAX);
-    name = libetpan_basename(basename_buf);
-  }
-  else {
-    name = NULL;
+    libetpan_basename(basename_buf);
   }
   
   encoding = NULL;

--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -6334,26 +6334,22 @@ mailimap_mailbox_data_list_parse(mailstream * fd, MMAPString * buffer,
   size_t cur_token;
   struct mailimap_mailbox_list * mb_list;
   int r;
-  int res;
 
   cur_token = * indx;
 
   r = mailimap_token_case_insensitive_parse(fd, buffer, &cur_token, "LIST");
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
 
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
 
   r = mailimap_mailbox_list_parse(fd, buffer, &cur_token, &mb_list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
 

--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -455,12 +455,6 @@ mailimap_header_list_parse(mailstream * fd, MMAPString * buffer,
 			   size_t progr_rate,
 			   progress_function * progr_fun);
 
-static int mailimap_literal_parse(mailstream * fd, MMAPString * buffer,
-				  size_t * indx, char ** result,
-				  size_t * result_len,
-				  size_t progr_rate,
-				  progress_function * progr_fun);
-
 static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
                                            size_t * indx, char ** result,
                                            size_t * result_len,
@@ -533,25 +527,6 @@ static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
 				     size_t progr_rate,
 				     progress_function * progr_fun);
 
-
-
-static int
-mailimap_message_data_parse(mailstream * fd, MMAPString * buffer,
-			    size_t * indx,
-			    struct mailimap_message_data ** result,
-			    size_t progr_rate,
-			    progress_function * progr_fun);
-
-
-
-
-
-static int
-mailimap_msg_att_parse(mailstream * fd, MMAPString * buffer,
-		       size_t * indx, struct mailimap_msg_att ** result,
-		       size_t progr_rate,
-		       progress_function * progr_fun);
-
 static int
 mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
                                 size_t * indx, struct mailimap_msg_att ** result,
@@ -570,14 +545,6 @@ mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer,
 			       struct mailimap_msg_att_dynamic ** result,
 			       size_t progr_rate,
 			       progress_function * progr_fun);
-
-
-static int
-mailimap_msg_att_static_parse(mailstream * fd, MMAPString * buffer,
-			      size_t * indx,
-			      struct mailimap_msg_att_static ** result,
-			      size_t progr_rate,
-			      progress_function * progr_fun);
 
 static int
 mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
@@ -6174,17 +6141,6 @@ err:
   return res;
 }
 
-static int mailimap_literal_parse(mailstream * fd, MMAPString * buffer,
-				  size_t * indx, char ** result,
-				  size_t * result_len,
-				  size_t progr_rate,
-				  progress_function * progr_fun)
-{
-  return mailimap_literal_parse_progress(fd, buffer, indx, result, result_len,
-                                         progr_rate, progr_fun,
-                                         NULL, NULL, NULL, NULL, NULL);
-}
-
 /*
   UNIMPLEMENTED
    login           = "LOGIN" SP userid SP password
@@ -6437,46 +6393,6 @@ mailimap_mailbox_data_search_parse(mailstream * fd, MMAPString * buffer,
   * result = number_list;
   * indx = final_token;
 
-  return MAILIMAP_NO_ERROR;
-}
-
-static int
-mailimap_mailbox_data_sort_parse(mailstream * fd, MMAPString * buffer,
-                                 size_t * indx,
-                                 clist ** result,
-                                 size_t progr_rate,
-                                 progress_function * progr_fun)
-{
-  size_t cur_token;
-  size_t final_token;
-  clist * number_list;
-  int r;
-  
-  cur_token = * indx;
-  
-  r = mailimap_token_case_insensitive_parse(fd, buffer,
-                                            &cur_token, "SORT");
-  if (r != MAILIMAP_NO_ERROR)
-    return r;
-  
-  final_token = cur_token;
-  number_list = NULL;
-  
-  r = mailimap_space_parse(fd, buffer, &cur_token);
-  if (r == MAILIMAP_NO_ERROR) {
-    r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &number_list,
-                                          (mailimap_struct_parser *)
-                                          mailimap_nz_number_alloc_parse,
-                                          (mailimap_struct_destructor *)
-                                          mailimap_number_alloc_free,
-                                          progr_rate, progr_fun);
-    if (r == MAILIMAP_NO_ERROR)
-      final_token = cur_token;
-  }
-  
-  * result = number_list;
-  * indx = final_token;
-  
   return MAILIMAP_NO_ERROR;
 }
 
@@ -7592,18 +7508,6 @@ mailimap_message_data_parse_progress(mailstream * fd, MMAPString * buffer,
   return res;
 }
 
-static int
-mailimap_message_data_parse(mailstream * fd, MMAPString * buffer,
-                            size_t * indx,
-                            struct mailimap_message_data ** result,
-                            size_t progr_rate,
-                            progress_function * progr_fun)
-{
-  return mailimap_message_data_parse_progress(fd, buffer, indx, result,
-                                              progr_rate, progr_fun,
-                                              NULL, NULL, NULL, NULL, NULL);
-}
-
 /*
    msg-att         = "(" (msg-att-dynamic / msg-att-static)
                       *(SP (msg-att-dynamic / msg-att-static)) ")"
@@ -7691,19 +7595,6 @@ mailimap_msg_att_item_parse_progress(mailstream * fd, MMAPString * buffer,
   return res;
 }
 
-static int
-mailimap_msg_att_item_parse(mailstream * fd, MMAPString * buffer,
-                            size_t * indx,
-                            struct mailimap_msg_att_item ** result,
-                            size_t progr_rate,
-                            progress_function * progr_fun)
-{
-  return mailimap_msg_att_item_parse_progress(fd, buffer, indx, result,
-                                              progr_rate, progr_fun,
-                                              NULL, NULL, NULL, NULL, NULL);
-  
-}
-
 /*
    msg-att         = "(" (msg-att-dynamic / msg-att-static)
                       *(SP (msg-att-dynamic / msg-att-static)) ")"
@@ -7770,17 +7661,6 @@ mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
   clist_free(list);
  err:
   return res;
-}
-
-static int
-mailimap_msg_att_parse(mailstream * fd, MMAPString * buffer,
-                       size_t * indx, struct mailimap_msg_att ** result,
-                       size_t progr_rate,
-                       progress_function * progr_fun)
-{
-  return mailimap_msg_att_parse_progress(fd, buffer, indx, result,
-                                         progr_rate, progr_fun,
-                                         NULL, NULL, NULL, NULL, NULL);
 }
 
 /*
@@ -7994,18 +7874,6 @@ mailimap_msg_att_rfc822_parse_progress(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-static int
-mailimap_msg_att_rfc822_parse(mailstream * fd, MMAPString * buffer,
-                              size_t * indx, char ** result,
-                              size_t * result_len,
-                              size_t progr_rate,
-                              progress_function * progr_fun)
-{
-  return mailimap_msg_att_rfc822_parse_progress(fd, buffer, indx, result, result_len,
-                                                progr_rate, progr_fun,
-                                                NULL, NULL, NULL, NULL, NULL);
-}
-
 /*
   "RFC822" ".HEADER" SP nstring
 */
@@ -8099,18 +7967,6 @@ mailimap_msg_att_rfc822_text_parse_progress(mailstream * fd, MMAPString * buffer
   * indx = cur_token;
 
   return MAILIMAP_NO_ERROR;
-}
-
-static int
-mailimap_msg_att_rfc822_text_parse(mailstream * fd, MMAPString * buffer,
-                                   size_t * indx, char ** result,
-                                   size_t * result_len,
-                                   size_t progr_rate,
-                                   progress_function * progr_fun)
-{
-  return mailimap_msg_att_rfc822_text_parse_progress(fd, buffer, indx, result, result_len,
-                                                     progr_rate, progr_fun,
-                                                     NULL, NULL, NULL, NULL, NULL);
 }
 
 /*
@@ -8329,19 +8185,6 @@ mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffe
   return res;
 }
 
-static int
-mailimap_msg_att_body_section_parse(mailstream * fd, MMAPString * buffer,
-                                             size_t * indx,
-                                             struct mailimap_msg_att_body_section **
-                                             result,
-                                             size_t progr_rate,
-                                             progress_function * progr_fun)
-{
-  return mailimap_msg_att_body_section_parse_progress(fd, buffer, indx, result,
-                                                      progr_rate, progr_fun,
-                                                      NULL, NULL, NULL, NULL, NULL);
-}
-
 /*
   "UID" SP uniqueid
 */
@@ -8544,18 +8387,6 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
     mailimap_msg_att_body_section_free(body_section);
  err:
   return res;
-}
-
-static int
-mailimap_msg_att_static_parse(mailstream * fd, MMAPString * buffer,
-                              size_t * indx,
-                              struct mailimap_msg_att_static ** result,
-                              size_t progr_rate,
-                              progress_function * progr_fun)
-{
-  return mailimap_msg_att_static_parse_progress(fd, buffer, indx, result,
-                                                progr_rate, progr_fun,
-                                                NULL, NULL, NULL, NULL, NULL);
 }
 
 /*

--- a/src/low-level/imap/mailimap_socket.c
+++ b/src/low-level/imap/mailimap_socket.c
@@ -57,7 +57,9 @@
 #define SERVICE_NAME_IMAP "imap2"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int mailimap_cfsocket_connect_voip(mailimap * f, const char * server, uint16_t port, int voip_enabled);
+#endif
 
 LIBETPAN_EXPORT
 int mailimap_socket_connect_voip(mailimap * f, const char * server, uint16_t port, int voip_enabled)
@@ -148,6 +150,7 @@ int mailimap_socket_starttls_with_callback(mailimap * f,
   return MAILIMAP_NO_ERROR;
 }
 
+#if HAVE_CFNETWORK
 static int mailimap_cfsocket_connect_voip(mailimap * f, const char * server, uint16_t port, int voip_enabled)
 {
   mailstream * stream;
@@ -159,6 +162,7 @@ static int mailimap_cfsocket_connect_voip(mailimap * f, const char * server, uin
   
   return mailimap_connect(f, stream);
 }
+#endif
 
 static int mailimap_cfsocket_starttls(mailimap * f)
 {

--- a/src/low-level/imap/mailimap_sort.c
+++ b/src/low-level/imap/mailimap_sort.c
@@ -361,14 +361,12 @@ mailimap_number_list_data_sort_parse(mailstream * fd, MMAPString * buffer,
   size_t cur_token;
   clist * number_list;
   int r;
-  int res;
   size_t final_token;
   
   cur_token = * indx;
   
   r = mailimap_token_case_insensitive_parse(fd, buffer, &cur_token, "SORT");
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
   

--- a/src/low-level/imap/mailimap_ssl.c
+++ b/src/low-level/imap/mailimap_ssl.c
@@ -57,7 +57,9 @@
 #define SERVICE_NAME_IMAPS "imaps"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int mailimap_cfssl_connect_voip(mailimap * f, const char * server, uint16_t port, int voip_enabled);
+#endif
 
 int mailimap_ssl_connect_with_callback(mailimap * f, const char * server, uint16_t port,
     void (* callback)(struct mailstream_ssl_context * ssl_context, void * data), void * data)
@@ -115,6 +117,7 @@ int mailimap_ssl_connect_voip(mailimap * f, const char * server, uint16_t port, 
       NULL, NULL);
 }
 
+#if HAVE_CFNETWORK
 static int mailimap_cfssl_connect_voip_ssl_level(mailimap * f, const char * server, uint16_t port, int voip_enabled, int ssl_level)
 {
   mailstream * stream;
@@ -139,3 +142,4 @@ static int mailimap_cfssl_connect_voip(mailimap * f, const char * server, uint16
 {
     return mailimap_cfssl_connect_voip_ssl_level(f, server, port, voip_enabled, MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL);
 }
+#endif

--- a/src/low-level/imap/quota_parser.c
+++ b/src/low-level/imap/quota_parser.c
@@ -187,10 +187,7 @@ mailimap_quota_quota_list_parse(mailstream * fd, MMAPString *buffer,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
-  size_t cur_token;
   int r;
-
-  cur_token = * indx;
 
   r = mailimap_quota_quota_list_empty_parse(fd, buffer, indx, result,
       progr_rate, progr_fun);

--- a/src/low-level/imap/xlist.c
+++ b/src/low-level/imap/xlist.c
@@ -196,26 +196,22 @@ mailimap_mailbox_data_xlist_parse(mailstream * fd, MMAPString * buffer,
   size_t cur_token;
   struct mailimap_mailbox_list * mb_list;
   int r;
-  int res;
   
   cur_token = * indx;
   
   r = mailimap_token_case_insensitive_parse(fd, buffer, &cur_token, "XLIST");
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
   
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
   
   r = mailimap_mailbox_list_parse(fd, buffer, &cur_token, &mb_list,
                                   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
-    res = r;
     return r;
   }
   

--- a/src/low-level/imap/xlist.c
+++ b/src/low-level/imap/xlist.c
@@ -182,7 +182,7 @@ free_list:
   clist_free(result_list);
 free_response:
   mailimap_response_free(response);
-err:
+
   return res;
 }
 

--- a/src/low-level/imf/mailimf_write_generic.c
+++ b/src/low-level/imf/mailimf_write_generic.c
@@ -639,16 +639,12 @@ int mailimf_header_string_write_driver(int (* do_write)(void *, const char *, si
   int state;
   const char * p;
   const char * word_begin;
-  const char * word_end;
-  const char * next_word;
   int first;
   
   state = STATE_BEGIN;
   
   p = str;
   word_begin = p;
-  word_end = p;
-  next_word = p;
   first = 1;
   
   while (length > 0) {

--- a/src/low-level/mbox/mailmbox.c
+++ b/src/low-level/mbox/mailmbox.c
@@ -522,7 +522,6 @@ static char * write_fixed_message(char * str,
 				  const char * message, size_t size,
 				  uint32_t uid, int force_no_uid)
 {
-  size_t fixed_size;
   size_t cur_token;
   size_t left;
   int end;
@@ -531,8 +530,6 @@ static char * write_fixed_message(char * str,
   size_t numlen;
 
   cur_token = 0;
-
-  fixed_size = 0;
 
   /* headers */
 
@@ -615,7 +612,6 @@ mailmbox_append_message_list_no_lock(struct mailmbox_folder * folder,
   char * str;
   unsigned int i;
   size_t from_size;
-  size_t maxuid;
   size_t left;
   size_t crlf_count;
 
@@ -632,8 +628,6 @@ mailmbox_append_message_list_no_lock(struct mailmbox_folder * folder,
 #else
     from_size = strftime(from_line, MAX_FROM_LINE_SIZE, "From - %c\n", &time_info);
 #endif
-
-  maxuid = /* */ folder->mb_max_uid;
 
   extra_size = 0;
   for(i = 0 ; i < carray_count(append_tab) ; i ++) {

--- a/src/low-level/mh/mailmh.c
+++ b/src/low-level/mh/mailmh.c
@@ -576,7 +576,6 @@ static int mailmh_folder_alloc_msg(struct mailmh_folder * folder,
   char * new_filename;
   size_t len;
   int got_file;
-  int r;
   
   len = strlen(folder->fl_filename) + 20;
   new_filename = malloc(len);
@@ -615,7 +614,7 @@ static int mailmh_folder_alloc_msg(struct mailmh_folder * folder,
       free(new_filename);
       
       if (k > MAX_TRY_ALLOC / 2) {
-	r = mailmh_folder_update(folder);
+	mailmh_folder_update(folder);
 	/* ignore errors */
       }
       

--- a/src/low-level/mime/mailmime.c
+++ b/src/low-level/mime/mailmime.c
@@ -1410,7 +1410,6 @@ int mailmime_language_parse(const char * message, size_t length,
   int r;
   int res;
   clist * list;
-  int first;
   struct mailmime_language * language;
 
   cur_token = * indx;
@@ -1420,8 +1419,6 @@ int mailmime_language_parse(const char * message, size_t length,
     res = MAILIMF_ERROR_MEMORY;
     goto err;
   }
-
-  first = TRUE;
 
   while (1) {
     char * atom;

--- a/src/low-level/mime/mailmime_content.c
+++ b/src/low-level/mime/mailmime_content.c
@@ -1617,7 +1617,6 @@ int mailmime_base64_body_parse(const char * message, size_t length,
 			       size_t * result_len)
 {
   size_t cur_token;
-  size_t i;
   char chunk[4];
   int chunk_index;
   char out[3];
@@ -1641,7 +1640,6 @@ int mailmime_base64_body_parse(const char * message, size_t length,
     goto err;
   }
 
-  i = 0;
   while (1) {
     signed char value;
 

--- a/src/low-level/nntp/newsnntp_socket.c
+++ b/src/low-level/nntp/newsnntp_socket.c
@@ -55,7 +55,9 @@
 #define SERVICE_NAME_NNTP "nntp"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int newsnntp_cfsocket_connect(newsnntp * f, const char * server, uint16_t port);
+#endif
 
 int newsnntp_socket_connect(newsnntp * f, const char * server, uint16_t port)
 {
@@ -94,6 +96,7 @@ int newsnntp_socket_connect(newsnntp * f, const char * server, uint16_t port)
   return newsnntp_connect(f, stream);
 }
 
+#if HAVE_CFNETWORK
 static int newsnntp_cfsocket_connect(newsnntp * f, const char * server, uint16_t port)
 {
   mailstream * stream;
@@ -105,3 +108,4 @@ static int newsnntp_cfsocket_connect(newsnntp * f, const char * server, uint16_t
   
   return newsnntp_connect(f, stream);
 }
+#endif

--- a/src/low-level/nntp/newsnntp_ssl.c
+++ b/src/low-level/nntp/newsnntp_ssl.c
@@ -54,7 +54,9 @@
 #define SERVICE_NAME_NNTPS "nntps"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int newsnntp_cfssl_connect(newsnntp * f, const char * server, uint16_t port);
+#endif
 
 int newsnntp_ssl_connect(newsnntp * f, const char * server, uint16_t port)
 {
@@ -101,6 +103,7 @@ int newsnntp_ssl_connect_with_callback(newsnntp * f, const char * server, uint16
   return newsnntp_connect(f, stream);
 }
 
+#if HAVE_CFNETWORK
 static int newsnntp_cfssl_connect_ssl_level(newsnntp * f, const char * server, uint16_t port, int ssl_level)
 {
   mailstream * stream;
@@ -120,9 +123,12 @@ static int newsnntp_cfssl_connect_ssl_level(newsnntp * f, const char * server, u
   
   return newsnntp_connect(f, stream);
 }
+#endif
 
+#if HAVE_CFNETWORK
 static int newsnntp_cfssl_connect(newsnntp * f, const char * server, uint16_t port)
 {
     return newsnntp_cfssl_connect_ssl_level(f, server, port, MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL);
 }
+#endif
 

--- a/src/low-level/pop3/mailpop3_socket.c
+++ b/src/low-level/pop3/mailpop3_socket.c
@@ -55,7 +55,9 @@
 #define SERVICE_NAME_POP3 "pop3"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int mailpop3_cfsocket_connect(mailpop3 * f, const char * server, uint16_t port);
+#endif
 
 int mailpop3_socket_connect(mailpop3 * f, const char * server, uint16_t port)
 {
@@ -140,6 +142,7 @@ int mailpop3_socket_starttls_with_callback(mailpop3 * f,
   return MAILPOP3_NO_ERROR;
 }
 
+#if HAVE_CFNETWORK
 static int mailpop3_cfsocket_connect(mailpop3 * f, const char * server, uint16_t port)
 {
   mailstream * stream;
@@ -151,6 +154,7 @@ static int mailpop3_cfsocket_connect(mailpop3 * f, const char * server, uint16_t
   
   return mailpop3_connect(f, stream);
 }
+#endif
 
 static int mailpop3_cfsocket_starttls(mailpop3 * f)
 {

--- a/src/low-level/pop3/mailpop3_ssl.c
+++ b/src/low-level/pop3/mailpop3_ssl.c
@@ -55,7 +55,9 @@
 #define SERVICE_NAME_POP3S "pop3s"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int mailpop3_cfssl_connect(mailpop3 * f, const char * server, uint16_t port);
+#endif
 
 int mailpop3_ssl_connect(mailpop3 * f, const char * server, uint16_t port)
 {
@@ -102,6 +104,7 @@ int mailpop3_ssl_connect_with_callback(mailpop3 * f, const char * server, uint16
   return mailpop3_connect(f, stream);
 }
 
+#if HAVE_CFNETWORK
 static int mailpop3_cfssl_connect_ssl_level(mailpop3 * f, const char * server, uint16_t port, int ssl_level)
 {
   mailstream * stream;
@@ -126,3 +129,4 @@ static int mailpop3_cfssl_connect(mailpop3 * f, const char * server, uint16_t po
 {
     return mailpop3_cfssl_connect_ssl_level(f, server, port, MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL);
 }
+#endif

--- a/src/low-level/smtp/mailsmtp_socket.c
+++ b/src/low-level/smtp/mailsmtp_socket.c
@@ -56,8 +56,10 @@
 #define SERVICE_NAME_SMTP "smtp"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int mailsmtp_cfsocket_connect(mailsmtp * session,
                                      const char * server, uint16_t port);
+#endif
 
 int mailsmtp_socket_connect(mailsmtp * session,
     const char * server, uint16_t port)
@@ -135,6 +137,7 @@ int mailsmtp_socket_starttls_with_callback(mailsmtp * session,
   return MAILSMTP_NO_ERROR;
 }
 
+#if HAVE_CFNETWORK
 static int mailsmtp_cfsocket_connect(mailsmtp * session,
                                      const char * server, uint16_t port)
 {
@@ -147,6 +150,7 @@ static int mailsmtp_cfsocket_connect(mailsmtp * session,
   
   return mailsmtp_connect(session, stream);
 }
+#endif
 
 static int mailsmtp_cfsocket_starttls(mailsmtp * session)
 {

--- a/src/low-level/smtp/mailsmtp_ssl.c
+++ b/src/low-level/smtp/mailsmtp_ssl.c
@@ -56,8 +56,10 @@
 #define SERVICE_NAME_SMTPS "smtps"
 #define SERVICE_TYPE_TCP "tcp"
 
+#if HAVE_CFNETWORK
 static int mailsmtp_cfssl_connect(mailsmtp * session,
                                   const char * server, uint16_t port);
+#endif
 
 int mailsmtp_ssl_connect(mailsmtp * session,
     const char * server, uint16_t port)
@@ -106,6 +108,7 @@ int mailsmtp_ssl_connect_with_callback(mailsmtp * session,
   return mailsmtp_connect(session, stream);
 }
 
+#if HAVE_CFNETWORK
 static int mailsmtp_cfssl_connect_ssl_level(mailsmtp * session,
                                             const char * server, uint16_t port, int ssl_level)
 {
@@ -132,3 +135,4 @@ static int mailsmtp_cfssl_connect(mailsmtp * session,
 {
     return mailsmtp_cfssl_connect_ssl_level(session, server, port, MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL);
 }
+#endif

--- a/tests/fetch-attachment.c
+++ b/tests/fetch-attachment.c
@@ -163,7 +163,6 @@ int main(int argc, char ** argv)
   char * cache_directory;
   char * flags_directory;
   struct mailstorage * storage;
-  int cached;
   struct mailfolder * folder;
 
   /* get options */
@@ -172,8 +171,6 @@ int main(int argc, char ** argv)
       &driver, &server, &port, &connection_type,
       &user, &password, &auth_type,
       &path, &cache_directory, &flags_directory);
-
-  cached = (cache_directory != NULL);
 
   /* build the storage structure */
 

--- a/tests/frm-simple.c
+++ b/tests/frm-simple.c
@@ -144,7 +144,6 @@ int main(int argc, char ** argv)
   char * cache_directory;
   char * flags_directory;
   struct mailstorage * storage;
-  int cached;
   struct mailfolder * folder;
 
   /* get options */
@@ -153,8 +152,6 @@ int main(int argc, char ** argv)
       &driver, &server, &port, &connection_type,
       &user, &password, &auth_type,
       &path, &cache_directory, &flags_directory);
-
-  cached = (cache_directory != NULL);
 
   /* build the storage structure */
 

--- a/tests/frm-tree.c
+++ b/tests/frm-tree.c
@@ -150,7 +150,6 @@ int main(int argc, char ** argv)
   char * cache_directory;
   char * flags_directory;
   struct mailstorage * storage;
-  int cached;
   struct mailfolder * folder;
 
   /* get options */
@@ -159,8 +158,6 @@ int main(int argc, char ** argv)
       &driver, &server, &port, &connection_type,
       &user, &password, &auth_type,
       &path, &cache_directory, &flags_directory);
-
-  cached = (cache_directory != NULL);
 
   /* build the storage structure */
 

--- a/tests/mime-parse.c
+++ b/tests/mime-parse.c
@@ -17,11 +17,6 @@ static void display_mime_data(struct mailmime_data * data)
   }
 }
 
-static void display_mime_parameter(struct mailmime_parameter * param)
-{
-  printf("%s = %s\n", param->pa_name, param->pa_value);
-}
-
 static void display_mime_dsp_parm(struct mailmime_disposition_parm * param)
 {
   switch (param->pa_type) {

--- a/tests/readmsg-simple.c
+++ b/tests/readmsg-simple.c
@@ -20,7 +20,6 @@ int main(int argc, char ** argv)
   char * cache_directory;
   char * flags_directory;
   struct mailstorage * storage;
-  int cached;
   struct mailfolder * folder;
 
   /* get options */
@@ -29,8 +28,6 @@ int main(int argc, char ** argv)
       &driver, &server, &port, &connection_type,
       &user, &password, &auth_type,
       &path, &cache_directory, &flags_directory);
-
-  cached = (cache_directory != NULL);
 
   /* build the storage structure */
 

--- a/tests/readmsg-uid.c
+++ b/tests/readmsg-uid.c
@@ -20,7 +20,6 @@ int main(int argc, char ** argv)
   char * cache_directory;
   char * flags_directory;
   struct mailstorage * storage;
-  int cached;
   struct mailfolder * folder;
 
   /* get options */
@@ -29,8 +28,6 @@ int main(int argc, char ** argv)
       &driver, &server, &port, &connection_type,
       &user, &password, &auth_type,
       &path, &cache_directory, &flags_directory);
-
-  cached = (cache_directory != NULL);
 
   /* build the storage structure */
 

--- a/tests/readmsg.c
+++ b/tests/readmsg.c
@@ -253,7 +253,6 @@ int main(int argc, char ** argv)
   char * cache_directory;
   char * flags_directory;
   struct mailstorage * storage;
-  int cached;
   struct mailfolder * folder;
 
   /* get options */
@@ -262,8 +261,6 @@ int main(int argc, char ** argv)
       &driver, &server, &port, &connection_type,
       &user, &password, &auth_type,
       &path, &cache_directory, &flags_directory);
-
-  cached = (cache_directory != NULL);
 
   /* build the storage structure */
 


### PR DESCRIPTION
These patches mainly get rid of unused variables or static functions, but there are also some changes around conditional code.