### PR TITLE
Added should_cancel callback to mailsmtp

### DIFF
--- a/src/data-types/mailstream_helper.h
+++ b/src/data-types/mailstream_helper.h
@@ -73,11 +73,25 @@ int mailstream_send_data(mailstream * s, const char * message,
 			  size_t size,
 			  size_t progr_rate,
 			  progress_function * progr_fun);
+  
+int mailstream_send_data_with_cancel(mailstream * s, const char * message,
+                                     size_t size,
+                                     size_t progr_rate,
+                                     progress_function * progr_fun,
+                                     should_cancel_function * cancel_fun,
+                                     void * context);
 
 int mailstream_send_data_with_context(mailstream * s, const char * message,
                                       size_t size,
                                       mailprogress_function * progr_fun,
                                       void * context);
+
+int mailstream_send_data_with_cancel_and_context(mailstream * s, const char * message,
+                                                 size_t size,
+                                                 mailprogress_function * progr_fun,
+                                                 void * progr_context,
+                                                 should_cancel_function * cancel_fun,
+                                                 void * cancel_context);
 
 size_t mailstream_get_data_crlf_size(const char * message, size_t size);
 

--- a/src/data-types/mailstream_types.h
+++ b/src/data-types/mailstream_types.h
@@ -46,6 +46,7 @@ extern "C" {
 #  include <libetpan/libetpan-config.h>
 #endif
 #include <libetpan/carray.h>
+#include <stdbool.h>
 
 struct _mailstream;
 
@@ -121,6 +122,8 @@ struct _mailstream_low {
 typedef void progress_function(size_t current, size_t maximum);
 
 typedef void mailprogress_function(size_t current, size_t maximum, void * context);
+
+typedef bool should_cancel_function(void * context);
 
 enum {
   MAILSTREAM_IDLE_ERROR,

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -137,6 +137,8 @@ mailsmtp * mailsmtp_new(size_t progr_rate,
   session->smtp_max_msg_size = 0;
   session->smtp_progress_fun = NULL;
   session->smtp_progress_context = NULL;
+  session->smtp_should_cancel_fun = NULL;
+  session->smtp_should_cancel_context = NULL;
 
 	session->smtp_timeout = 0;
 
@@ -1028,6 +1030,12 @@ static int read_response(mailsmtp * session)
   mmap_string_assign(session->response_buffer, "");
 
   do {
+    if (session->smtp_should_cancel_fun != NULL) {
+      if ((* session->smtp_should_cancel_fun)(session->smtp_should_cancel_context)) {
+        code = 0;
+        break;
+      }
+    }
     line = read_line(session);
 
     if (line != NULL) {
@@ -1072,13 +1080,15 @@ static int send_command_private(mailsmtp * f, char * command, int can_be_publish
 static int send_data(mailsmtp * session, const char * message, size_t size)
 {
   if (session->smtp_progress_fun != NULL) {
-    if (mailstream_send_data_with_context(session->stream, message, size,
-                             session->smtp_progress_fun, session->smtp_progress_context) == -1)
+    if (mailstream_send_data_with_cancel_and_context(session->stream, message, size,
+                             session->smtp_progress_fun, session->smtp_progress_context,
+                             session->smtp_should_cancel_fun, session->smtp_should_cancel_context) == -1)
       return -1;
   }
   else {
-    if (mailstream_send_data(session->stream, message, size,
-                             session->progr_rate, session->progr_fun) == -1)
+    if (mailstream_send_data_with_cancel(session->stream, message, size,
+                             session->progr_rate, session->progr_fun,
+                             session->smtp_should_cancel_fun, session->smtp_should_cancel_context) == -1)
       return -1;
   }
 
@@ -1461,6 +1471,14 @@ void mailsmtp_set_progress_callback(mailsmtp * session,
 {
   session->smtp_progress_fun = progr_fun;
   session->smtp_progress_context = context;
+}
+
+void mailsmtp_set_should_cancel_callback(mailsmtp * session,
+                                         should_cancel_function * cancel_fun,
+                                         void * context)
+{
+  session->smtp_should_cancel_fun = cancel_fun;
+  session->smtp_should_cancel_context = context;
 }
 
 void mailsmtp_set_timeout(mailsmtp * session, time_t timeout)

--- a/src/low-level/smtp/mailsmtp.h
+++ b/src/low-level/smtp/mailsmtp.h
@@ -159,6 +159,11 @@ LIBETPAN_EXPORT
 void mailsmtp_set_progress_callback(mailsmtp * session,
                                     mailprogress_function * progr_fun,
                                     void * context);
+
+LIBETPAN_EXPORT
+void mailsmtp_set_should_cancel_callback(mailsmtp * session,
+                                         should_cancel_function * cancel_fun,
+                                         void * context);
    
 LIBETPAN_EXPORT
 void mailsmtp_set_logger(mailsmtp * session, void (* logger)(mailsmtp * session, int log_type,

--- a/src/low-level/smtp/mailsmtp_types.h
+++ b/src/low-level/smtp/mailsmtp_types.h
@@ -129,6 +129,8 @@ struct mailsmtp {
 
   mailprogress_function * smtp_progress_fun;
   void * smtp_progress_context;
+  should_cancel_function * smtp_should_cancel_fun;
+  void * smtp_should_cancel_context;
     
 	int response_code;
 	


### PR DESCRIPTION
Added should_cancel callback to mailsmtp that allows to request sending operation canceling. It will be used in MCSMTPSession class