### PR TITLE
Workaround issue with Rambler IMAP provider.

### DIFF
--- a/src/low-level/imap/acl_parser.c
+++ b/src/low-level/imap/acl_parser.c
@@ -41,7 +41,7 @@
 #include <stdlib.h>
 
 int
-mailimap_acl_acl_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_acl_acl_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_acl_acl_data ** result,
     size_t progr_rate,
@@ -71,7 +71,7 @@ mailimap_acl_acl_data_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, &cur_token, &mailbox,
+  r = mailimap_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &mailbox,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -84,7 +84,7 @@ mailimap_acl_acl_data_parse(mailstream * fd, MMAPString *buffer,
     goto mailbox_free;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
         &cur_token, &ir_list,
         (mailimap_struct_parser * )
         mailimap_acl_identifier_rights_parse,
@@ -121,7 +121,7 @@ mailimap_acl_acl_data_parse(mailstream * fd, MMAPString *buffer,
 }
 
 int
-mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_acl_listrights_data ** result,
     size_t progr_rate,
@@ -153,7 +153,7 @@ mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, &cur_token, &mailbox,
+  r = mailimap_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &mailbox,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -166,7 +166,7 @@ mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString *buffer,
     goto mailbox_free;
   }
 
-  r = mailimap_acl_identifier_parse(fd, buffer, &cur_token, &identifier,
+  r = mailimap_acl_identifier_parse(fd, buffer, parser_ctx, &cur_token, &identifier,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -179,7 +179,7 @@ mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString *buffer,
     goto identifier_free;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
         &cur_token, &rights_list,
         (mailimap_struct_parser * )
         mailimap_acl_rights_parse,
@@ -218,7 +218,7 @@ mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString *buffer,
 }
 
 int
-mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_acl_myrights_data ** result,
     size_t progr_rate,
@@ -249,7 +249,7 @@ mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, &cur_token, &mailbox,
+  r = mailimap_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &mailbox,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -262,7 +262,7 @@ mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString *buffer,
     goto mailbox_free;
   }
 
-  r = mailimap_acl_rights_parse(fd, buffer, &cur_token, &rights,
+  r = mailimap_acl_rights_parse(fd, buffer, parser_ctx, &cur_token, &rights,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -290,7 +290,7 @@ mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString *buffer,
 
 int
 mailimap_acl_identifier_rights_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_acl_identifier_rights ** result,
     size_t progr_rate,
     progress_function * progr_fun)
@@ -307,7 +307,7 @@ mailimap_acl_identifier_rights_parse(mailstream * fd,
   identifier = NULL; /* XXX - removes a gcc warning */
   rights = NULL;
 
-  r = mailimap_acl_identifier_parse(fd, buffer, &cur_token, &identifier,
+  r = mailimap_acl_identifier_parse(fd, buffer, parser_ctx, &cur_token, &identifier,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -320,7 +320,7 @@ mailimap_acl_identifier_rights_parse(mailstream * fd,
     goto identifier_free;
   }
 
-  r = mailimap_acl_rights_parse(fd, buffer, &cur_token, &rights,
+  r = mailimap_acl_rights_parse(fd, buffer, parser_ctx, &cur_token, &rights,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -348,20 +348,20 @@ mailimap_acl_identifier_rights_parse(mailstream * fd,
 
 int
 mailimap_acl_identifier_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     char ** result, size_t progr_rate,
     progress_function * progr_fun)
 {
-  return mailimap_astring_parse(fd, buffer, indx, result,
+  return mailimap_astring_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
 }
 
 int mailimap_acl_rights_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     char ** result, size_t progr_rate,
     progress_function * progr_fun)
 {
-  return mailimap_astring_parse(fd, buffer, indx, result,
+  return mailimap_astring_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
 }
 
@@ -378,7 +378,7 @@ int mailimap_acl_rights_parse(mailstream * fd,
 */
 
 int mailimap_acl_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun)
@@ -401,7 +401,7 @@ int mailimap_acl_parse(int calling_parser, mailstream * fd,
   switch (calling_parser)
   {
     case MAILIMAP_EXTENDED_PARSER_MAILBOX_DATA:
-      r = mailimap_acl_acl_data_parse(fd, buffer, indx,
+      r = mailimap_acl_acl_data_parse(fd, buffer, parser_ctx, indx,
         &acl_data, progr_rate, progr_fun);
       if (r == MAILIMAP_NO_ERROR) {
         type = MAILIMAP_ACL_TYPE_ACL_DATA;
@@ -409,7 +409,7 @@ int mailimap_acl_parse(int calling_parser, mailstream * fd,
       }
 
       if (r == MAILIMAP_ERROR_PARSE) {
-        r = mailimap_acl_listrights_data_parse(fd, buffer, indx,
+        r = mailimap_acl_listrights_data_parse(fd, buffer, parser_ctx, indx,
           &lr_data, progr_rate, progr_fun);
         if (r == MAILIMAP_NO_ERROR) {
           type = MAILIMAP_ACL_TYPE_LISTRIGHTS_DATA;
@@ -418,7 +418,7 @@ int mailimap_acl_parse(int calling_parser, mailstream * fd,
       }
 
       if (r == MAILIMAP_ERROR_PARSE) {
-        r = mailimap_acl_myrights_data_parse(fd, buffer, indx,
+        r = mailimap_acl_myrights_data_parse(fd, buffer, parser_ctx, indx,
           &mr_data, progr_rate, progr_fun);
         if (r == MAILIMAP_NO_ERROR) {
           type = MAILIMAP_ACL_TYPE_MYRIGHTS_DATA;

--- a/src/low-level/imap/acl_parser.h
+++ b/src/low-level/imap/acl_parser.h
@@ -41,21 +41,21 @@ extern "C" {
 #include "acl_types.h"
 
 int
-mailimap_acl_acl_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_acl_acl_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_acl_acl_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_acl_listrights_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_acl_listrights_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_acl_myrights_data ** result,
     size_t progr_rate,
@@ -63,24 +63,24 @@ mailimap_acl_myrights_data_parse(mailstream * fd, MMAPString *buffer,
 
 int
 mailimap_acl_identifier_rights_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_acl_identifier_rights ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
 mailimap_acl_identifier_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     char ** result, size_t progr_rate,
     progress_function * progr_fun);
 
 int mailimap_acl_rights_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     char ** result, size_t progr_rate,
     progress_function * progr_fun);
 
 int mailimap_acl_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);

--- a/src/low-level/imap/annotatemore_parser.c
+++ b/src/low-level/imap/annotatemore_parser.c
@@ -41,7 +41,7 @@
 #include <stdlib.h>
 
 int
-mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, struct mailimap_annotatemore_annotate_data ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -69,7 +69,7 @@ mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, &cur_token, &mailbox,
+  r = mailimap_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &mailbox,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -82,7 +82,7 @@ mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString *buffer,
     goto mailbox_free;
   }
 
-  r = mailimap_annotatemore_entry_list_parse(fd, buffer, &cur_token,
+  r = mailimap_annotatemore_entry_list_parse(fd, buffer, parser_ctx, &cur_token,
           &entry_list, progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -110,7 +110,7 @@ mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString *buffer,
 }
 
 int
-mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_entry_list ** result,
     size_t progr_rate,
@@ -131,7 +131,7 @@ mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString *buffer,
   en_list = NULL;
   en_att_list = NULL;
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
         &cur_token, &en_att_list,
         (mailimap_struct_parser * )
         mailimap_annotatemore_entry_att_parse,
@@ -142,13 +142,13 @@ mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString *buffer,
     type = MAILIMAP_ANNOTATEMORE_ENTRY_LIST_TYPE_ENTRY_ATT_LIST;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto err;
     }
 
-    r = mailimap_struct_spaced_list_parse(fd, buffer,
+    r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
           &cur_token, &en_list,
           (mailimap_struct_parser * )
           mailimap_annotatemore_entry_parse,
@@ -160,7 +160,7 @@ mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString *buffer,
       goto err;
     }
 
-    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto en_list_free;
@@ -197,7 +197,7 @@ mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString *buffer,
 }
 
 int
-mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_entry_att ** result,
     size_t progr_rate,
@@ -213,7 +213,7 @@ mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString *buffer,
   cur_token = * indx;
   entry = NULL;
 
-  r = mailimap_annotatemore_entry_parse(fd, buffer, &cur_token, &entry,
+  r = mailimap_annotatemore_entry_parse(fd, buffer, parser_ctx, &cur_token, &entry,
       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -226,13 +226,13 @@ mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString *buffer,
     goto entry_free;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto entry_free;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
         &cur_token, &list,
         (mailimap_struct_parser * )
         mailimap_annotatemore_att_value_parse,
@@ -244,7 +244,7 @@ mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString *buffer,
     goto entry_free;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto list_free;
@@ -272,7 +272,7 @@ mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString *buffer,
 }
 
 int
-mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_att_value ** result,
     size_t progr_rate,
@@ -289,7 +289,7 @@ mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString *buffer,
   attrib = NULL;
   value = NULL;
 
-  r = mailimap_annotatemore_attrib_parse(fd, buffer, &cur_token, &attrib,
+  r = mailimap_annotatemore_attrib_parse(fd, buffer, parser_ctx, &cur_token, &attrib,
             progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -302,7 +302,7 @@ mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString *buffer,
     goto attrib_free;
   }
 
-  r = mailimap_annotatemore_value_parse(fd, buffer, &cur_token, &value,
+  r = mailimap_annotatemore_value_parse(fd, buffer, parser_ctx, &cur_token, &value,
             progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -329,35 +329,35 @@ mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString *buffer,
 }
 
 int
-mailimap_annotatemore_attrib_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_attrib_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
               size_t * indx, char ** result,
               size_t progr_rate, progress_function * progr_fun)
 {
-  return mailimap_string_parse(fd, buffer, indx, result, NULL,
+  return mailimap_string_parse(fd, buffer, parser_ctx, indx, result, NULL,
     progr_rate, progr_fun);
 }
 
 int
-mailimap_annotatemore_value_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_value_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
               size_t * indx, char ** result,
 		          size_t progr_rate, progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
     progr_rate, progr_fun);
 }
 
 int
-mailimap_annotatemore_entry_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_entry_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
               size_t * indx, char ** result,
               size_t progr_rate, progress_function * progr_fun)
 {
-  return mailimap_string_parse(fd, buffer, indx, result, NULL,
+  return mailimap_string_parse(fd, buffer, parser_ctx, indx, result, NULL,
     progr_rate, progr_fun);
 }
 
 int
 mailimap_annotatemore_text_code_annotatemore_parse(mailstream * fd,
-              MMAPString *buffer, size_t * indx, int * result,
+              MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, int * result,
               size_t progr_rate, progress_function * progr_fun)
 {
   size_t cur_token;
@@ -415,7 +415,7 @@ mailimap_annotatemore_text_code_annotatemore_parse(mailstream * fd,
                            ; new response codes for SETANNOTATION failures
 */
 int mailimap_annotatemore_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun)
@@ -428,7 +428,7 @@ int mailimap_annotatemore_parse(int calling_parser, mailstream * fd,
   switch (calling_parser)
   {
     case MAILIMAP_EXTENDED_PARSER_RESPONSE_DATA:
-      r = mailimap_annotatemore_annotate_data_parse(fd, buffer, indx,
+      r = mailimap_annotatemore_annotate_data_parse(fd, buffer, parser_ctx, indx,
         &an_data, progr_rate, progr_fun);
       if (r != MAILIMAP_NO_ERROR)
         return r;
@@ -440,7 +440,7 @@ int mailimap_annotatemore_parse(int calling_parser, mailstream * fd,
       }
       break;
     case MAILIMAP_EXTENDED_PARSER_RESP_TEXT_CODE:
-      r = mailimap_annotatemore_text_code_annotatemore_parse(fd, buffer, indx,
+      r = mailimap_annotatemore_text_code_annotatemore_parse(fd, buffer, parser_ctx, indx,
         &resp_text_code, progr_rate, progr_fun);
       if (r != MAILIMAP_NO_ERROR)
         return r;

--- a/src/low-level/imap/annotatemore_parser.h
+++ b/src/low-level/imap/annotatemore_parser.h
@@ -41,58 +41,58 @@ extern "C" {
 #include "annotatemore_types.h"
 
 int
-mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_annotate_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_annotate_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_entry_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_entry_list ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_entry_att_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_entry_att ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_att_value_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_annotatemore_att_value ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_annotatemore_attrib_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_attrib_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, char ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_annotatemore_value_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_value_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, char ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
-mailimap_annotatemore_entry_parse(mailstream * fd, MMAPString *buffer,
+mailimap_annotatemore_entry_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, char ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 int
 mailimap_annotatemore_text_code_annotatemore_parse(mailstream * fd,
-    MMAPString *buffer, size_t * indx, int * result,
+    MMAPString *buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, int * result,
     size_t progr_rate, progress_function * progr_fun);
 
 int mailimap_annotatemore_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);

--- a/src/low-level/imap/condstore.c
+++ b/src/low-level/imap/condstore.c
@@ -156,7 +156,7 @@ static void
 
 static int
 	mailimap_condstore_extension_parse(int calling_parser, mailstream * fd,
-	MMAPString * buffer, size_t * indx,
+	MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 	struct mailimap_extension_data ** result,
 	size_t progr_rate, progress_function * progr_fun);
 
@@ -635,7 +635,7 @@ int mailimap_has_condstore(mailimap * session)
 }
 
 static int fetch_data_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx, struct mailimap_condstore_fetch_mod_resp ** result)
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, struct mailimap_condstore_fetch_mod_resp ** result)
 {
   int r;
   size_t cur_token;
@@ -657,15 +657,15 @@ static int fetch_data_parse(mailstream * fd,
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
-  r = mailimap_mod_sequence_value_parse(fd, buffer, &cur_token, &value);
+  r = mailimap_mod_sequence_value_parse(fd, buffer, parser_ctx, &cur_token, &value);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
@@ -682,7 +682,7 @@ static int fetch_data_parse(mailstream * fd,
 }
 
 static int resp_text_code_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx, struct mailimap_condstore_resptextcode ** result)
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, struct mailimap_condstore_resptextcode ** result)
 {
   size_t cur_token;
   struct mailimap_condstore_resptextcode * resptextcode;
@@ -704,7 +704,7 @@ static int resp_text_code_parse(mailstream * fd,
     if (r != MAILIMAP_NO_ERROR) {
       return r;
     }
-    r = mailimap_mod_sequence_value_parse(fd, buffer, &cur_token, &value);
+    r = mailimap_mod_sequence_value_parse(fd, buffer, parser_ctx, &cur_token, &value);
     if (r != MAILIMAP_NO_ERROR) {
       return r;
     }
@@ -738,7 +738,7 @@ static int resp_text_code_parse(mailstream * fd,
       return r;
     }
     
-    r = mailimap_set_parse(fd, buffer, &cur_token, &set);
+    r = mailimap_set_parse(fd, buffer, parser_ctx, &cur_token, &set);
     if (r != MAILIMAP_NO_ERROR) {
       return r;
     }
@@ -758,7 +758,7 @@ static int resp_text_code_parse(mailstream * fd,
 }
 
 static int search_data_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx, struct mailimap_condstore_search ** result)
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, struct mailimap_condstore_search ** result)
 {
   int r;
   clist * number_list;
@@ -788,7 +788,7 @@ static int search_data_parse(mailstream * fd,
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &number_list,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &number_list,
     (mailimap_struct_parser *)
     mailimap_nz_number_alloc_parse,
     (mailimap_struct_destructor *)
@@ -804,17 +804,17 @@ static int search_data_parse(mailstream * fd,
     res = r;
     goto free_number_list;
   }
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_number_list;
   }
-  r = mailimap_mod_sequence_value_parse(fd, buffer, &cur_token, &value);
+  r = mailimap_mod_sequence_value_parse(fd, buffer, parser_ctx, &cur_token, &value);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_number_list;
   }
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_number_list;
@@ -839,7 +839,7 @@ err:
 }
 
 static int status_info_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx, struct mailimap_condstore_status_info ** result)
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, struct mailimap_condstore_status_info ** result)
 {
   int r;
   struct mailimap_condstore_status_info * status_info;
@@ -849,7 +849,7 @@ static int status_info_parse(mailstream * fd,
   
   cur_token = * indx;
   
-  r = mailimap_status_att_parse(fd, buffer, &cur_token, &status_att);
+  r = mailimap_status_att_parse(fd, buffer, parser_ctx, &cur_token, &status_att);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
@@ -859,7 +859,7 @@ static int status_info_parse(mailstream * fd,
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
-  r = mailimap_mod_sequence_value_parse(fd, buffer, &cur_token, &value);
+  r = mailimap_mod_sequence_value_parse(fd, buffer, parser_ctx, &cur_token, &value);
   if (r != MAILIMAP_NO_ERROR)
     return r;
     
@@ -875,7 +875,7 @@ static int status_info_parse(mailstream * fd,
 
 static int
 	mailimap_condstore_extension_parse(int calling_parser, mailstream * fd,
-	MMAPString * buffer, size_t * indx,
+	MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 	struct mailimap_extension_data ** result,
 	size_t progr_rate, progress_function * progr_fun)
 {
@@ -889,7 +889,7 @@ static int
       struct mailimap_condstore_fetch_mod_resp * fetch_data;
       struct mailimap_extension_data * ext_data;
 
-      r = fetch_data_parse(fd, buffer, &cur_token, &fetch_data);
+      r = fetch_data_parse(fd, buffer, parser_ctx, &cur_token, &fetch_data);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       ext_data = mailimap_extension_data_new(&mailimap_extension_condstore,
@@ -907,7 +907,7 @@ static int
       struct mailimap_condstore_resptextcode * resptextcode;
       struct mailimap_extension_data * ext_data;
       
-      r = resp_text_code_parse(fd, buffer, &cur_token, &resptextcode);
+      r = resp_text_code_parse(fd, buffer, parser_ctx, &cur_token, &resptextcode);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       ext_data = mailimap_extension_data_new(&mailimap_extension_condstore,
@@ -926,7 +926,7 @@ static int
       struct mailimap_extension_data * ext_data;
       
       search_data = NULL;
-      r = search_data_parse(fd, buffer, &cur_token, &search_data);
+      r = search_data_parse(fd, buffer, parser_ctx, &cur_token, &search_data);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       ext_data = mailimap_extension_data_new(&mailimap_extension_condstore,
@@ -944,7 +944,7 @@ static int
       struct mailimap_condstore_status_info * status_info;
       struct mailimap_extension_data * ext_data;
       
-      r = status_info_parse(fd, buffer, &cur_token, &status_info);
+      r = status_info_parse(fd, buffer, parser_ctx, &cur_token, &status_info);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       ext_data = mailimap_extension_data_new(&mailimap_extension_condstore,

--- a/src/low-level/imap/enable.c
+++ b/src/low-level/imap/enable.c
@@ -44,7 +44,7 @@ enum {
 
 static int
 mailimap_enable_extension_parse(int calling_parser, mailstream * fd,
-                               MMAPString * buffer, size_t * indx,
+                               MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                struct mailimap_extension_data ** result,
                                size_t progr_rate, progress_function * progr_fun);
 
@@ -213,7 +213,7 @@ mailimap_enable_extension_data_free(struct mailimap_extension_data * ext_data)
   free(ext_data);
 }
 
-static int mailimap_enable_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_enable_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 	size_t * indx,
 	struct mailimap_capability_data ** result,
 	size_t progr_rate,
@@ -233,7 +233,7 @@ static int mailimap_enable_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
   
-  r = mailimap_capability_list_parse(fd, buffer, &cur_token,
+  r = mailimap_capability_list_parse(fd, buffer, parser_ctx, &cur_token,
                                      &cap_list,
                                      progr_rate, progr_fun);
   if (r == MAILIMAP_ERROR_PARSE) {
@@ -271,7 +271,7 @@ err:
 
 static int
 mailimap_enable_extension_parse(int calling_parser, mailstream * fd,
-                                MMAPString * buffer, size_t * indx,
+                                MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                 struct mailimap_extension_data ** result,
                                 size_t progr_rate, progress_function * progr_fun)
 {
@@ -287,7 +287,7 @@ mailimap_enable_extension_parse(int calling_parser, mailstream * fd,
   switch (calling_parser)
   {
     case MAILIMAP_EXTENDED_PARSER_RESPONSE_DATA:
-			r = mailimap_enable_parse(fd, buffer, &cur_token,
+			r = mailimap_enable_parse(fd, buffer, parser_ctx, &cur_token,
 		    &capabilities, progr_rate, progr_fun);
       if (r == MAILIMAP_NO_ERROR) {
         type = MAILIMAP_ENABLE_TYPE_ENABLE;

--- a/src/low-level/imap/idle.c
+++ b/src/low-level/imap/idle.c
@@ -101,7 +101,7 @@ int mailimap_idle(mailimap * session)
   indx = 0;
 
   r = mailimap_struct_multiple_parse(session->imap_stream,
-					session->imap_stream_buffer,
+					session->imap_stream_buffer, NULL,
 					&indx,
 					&resp_data_list,
 					(mailimap_struct_parser *)
@@ -118,7 +118,7 @@ int mailimap_idle(mailimap * session)
   }
 
   r = mailimap_continue_req_parse(session->imap_stream,
-      session->imap_stream_buffer,
+      session->imap_stream_buffer, NULL,
       &indx, &cont_req,
       session->imap_progr_rate, session->imap_progr_fun);
   

--- a/src/low-level/imap/mailimap.h
+++ b/src/low-level/imap/mailimap.h
@@ -862,6 +862,33 @@ int mailimap_is_163_workaround_enabled(mailimap * session);
 LIBETPAN_EXPORT    
 void mailimap_set_163_workaround_enabled(mailimap * session, int enabled);
 
+#ifndef LIBETPAN_HAS_MAILIMAP_RAMBLER_WORKAROUND
+  #define LIBETPAN_HAS_MAILIMAP_RAMBLER_WORKAROUND	1
+#endif
+
+/*
+    Enable workaround for Rambler IMAP server.
+
+    Occasionally, for large attachments (~20MB) Rambler returns wrong length of the literal.
+    Since this workaround is not completely free from false positives, by default is is off.
+
+    It is proposed to enable it only during downloading large attachments from Rambler:
+
+    @code
+    if (encoding is (base64 or uuencode) and server is rambler.ru) {
+        mailimap_set_rambler_workaround_enabled(imap, 1);
+            … fetch part ...
+        mailimap_set_rambler_workaround_enabled(imap, 0);
+    }
+    @endcode
+*/
+
+LIBETPAN_EXPORT
+int mailimap_is_rambler_workaround_enabled(mailimap * session);
+
+LIBETPAN_EXPORT
+void mailimap_set_rambler_workaround_enabled(mailimap * session, int enabled);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/low-level/imap/mailimap_extension.c
+++ b/src/low-level/imap/mailimap_extension.c
@@ -104,7 +104,7 @@ mailimap_extension_unregister_all(void)
 LIBETPAN_EXPORT
 int
 mailimap_extension_data_parse(int calling_parser,
-        mailstream * fd, MMAPString * buffer,
+        mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
         size_t * indx, struct mailimap_extension_data ** result,
         size_t progr_rate,
         progress_function * progr_fun)
@@ -117,7 +117,7 @@ mailimap_extension_data_parse(int calling_parser,
     struct mailimap_extension_api * ext;
     
     ext = internal_extension_list[i];
-    r = ext->ext_parser(calling_parser, fd, buffer, indx, result,
+    r = ext->ext_parser(calling_parser, fd, buffer, parser_ctx, indx, result,
         progr_rate, progr_fun);
     if (r != MAILIMAP_ERROR_PARSE)
       return r;
@@ -131,7 +131,7 @@ mailimap_extension_data_parse(int calling_parser,
     struct mailimap_extension_api * ext;
     
     ext = clist_content(cur);
-    r = ext->ext_parser(calling_parser, fd, buffer, indx, result,
+    r = ext->ext_parser(calling_parser, fd, buffer, parser_ctx, indx, result,
         progr_rate, progr_fun);
     if (r != MAILIMAP_ERROR_PARSE)
       return r;

--- a/src/low-level/imap/mailimap_extension.h
+++ b/src/low-level/imap/mailimap_extension.h
@@ -67,7 +67,7 @@ mailimap_extension_unregister_all(void);
 LIBETPAN_EXPORT
 int
 mailimap_extension_data_parse(int calling_parser,
-        mailstream * fd, MMAPString * buffer,
+        mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
         size_t * indx, struct mailimap_extension_data ** result,
         size_t progr_rate,
         progress_function * progr_fun);

--- a/src/low-level/imap/mailimap_extension_types.h
+++ b/src/low-level/imap/mailimap_extension_types.h
@@ -88,7 +88,7 @@ struct mailimap_extension_api {
   int ext_id; /* use -1 if this is an extension outside libetpan */
 
   int (* ext_parser)(int calling_parser, mailstream * fd,
-            MMAPString * buffer, size_t * indx,
+            MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
             struct mailimap_extension_data ** result,
             size_t progr_rate,
             progress_function * progr_fun);

--- a/src/low-level/imap/mailimap_id_parser.h
+++ b/src/low-level/imap/mailimap_id_parser.h
@@ -41,7 +41,7 @@ extern "C" {
 #include <libetpan/mailimap_id_types.h>
 
 int mailimap_id_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);

--- a/src/low-level/imap/mailimap_oauth2.c
+++ b/src/low-level/imap/mailimap_oauth2.c
@@ -84,7 +84,7 @@ int mailimap_oauth2_authenticate(mailimap * session, const char *auth_user, cons
 
   indx = 0;
   r = mailimap_continue_req_parse(session->imap_stream,
-      session->imap_stream_buffer,
+      session->imap_stream_buffer, NULL,
       &indx, &cont_req,
       session->imap_progr_rate, session->imap_progr_fun);
   if (r == MAILIMAP_NO_ERROR) {

--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -69,7 +69,7 @@
 /* ************************************************************************* */
 
 
-typedef int mailimap_struct_parser_progress(mailstream * fd, MMAPString * buffer,
+typedef int mailimap_struct_parser_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                             size_t * indx, void * result,
                                             size_t progr_rate,
                                             progress_function * progr_fun,
@@ -79,43 +79,43 @@ typedef int mailimap_struct_parser_progress(mailstream * fd, MMAPString * buffer
                                             mailimap_msg_att_handler * msg_att_handler,
                                             void * msg_att_context);
 
-static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_address_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx,
 				  struct mailimap_address ** result,
 				  size_t progr_rate,
 				  progress_function * progr_fun);
 
-static int mailimap_addr_adl_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_adl_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, char ** result,
 				   size_t progr_rate,
 				   progress_function * progr_fun);
 
-static int mailimap_addr_host_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_host_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, char ** result,
 				    size_t progr_rate,
 				    progress_function * progr_fun);
 
-static int mailimap_addr_mailbox_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_mailbox_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx, char ** result,
 				       size_t progr_rate,
 				       progress_function * progr_fun);
 
-static int mailimap_addr_name_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_name_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, char ** result,
 				    size_t progr_rate,
 				    progress_function * progr_fun);
 
-static int mailimap_auth_type_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_auth_type_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, char ** result,
 				    size_t progr_rate,
 				    progress_function * progr_fun);
 
-static int mailimap_base64_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_base64_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx, char ** result,
 				 size_t progr_rate,
 				 progress_function * progr_fun);
 
-static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body ** result,
 			       size_t progr_rate,
@@ -123,7 +123,7 @@ static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_extension ** result,
 			      size_t progr_rate,
@@ -131,7 +131,7 @@ mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_ext_1part ** result,
 			      size_t progr_rate,
@@ -140,7 +140,7 @@ mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_ext_mpart ** result,
 			      size_t progr_rate,
@@ -148,20 +148,20 @@ mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_body_fields ** result,
 			   size_t progr_rate,
 			   progress_function * progr_fun);
 
-static int mailimap_body_fld_desc_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_desc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					size_t * indx, char ** result,
 					size_t progr_rate,
 					progress_function * progr_fun);
 
 
 static int
-mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_body_fld_dsp ** result,
 			    size_t progr_rate,
@@ -170,7 +170,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_body_fld_enc ** result,
 			    size_t progr_rate,
@@ -178,40 +178,40 @@ mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer,
 
 
 
-static int mailimap_body_fld_id_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_id_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				      size_t * indx, char ** result,
 				      size_t progr_rate,
 				      progress_function * progr_fun);
 
 
 static int
-mailimap_body_fld_lang_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_lang_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_body_fld_lang ** result,
 			     size_t progr_rate,
 			     progress_function * progr_fun);
 
 static int mailimap_body_fld_lines_parse(mailstream * fd,
-					 MMAPString * buffer, size_t * indx,
+					 MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 					 uint32_t * result);
 
-static int mailimap_body_fld_loc_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_loc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                        size_t * indx, char ** result,
                                        size_t progr_rate,
                                        progress_function * progr_fun);
 
-static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx, char ** result,
 				       size_t progr_rate,
 				       progress_function * progr_fun);
 
 static int mailimap_body_fld_octets_parse(mailstream * fd,
-					  MMAPString * buffer, size_t * indx,
+					  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 					  uint32_t * result);
 
 static int
 mailimap_body_fld_param_parse(mailstream * fd,
-			      MMAPString * buffer, size_t * indx,
+			      MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 			      struct mailimap_body_fld_param ** result,
 			      size_t progr_rate,
 			      progress_function * progr_fun);
@@ -219,7 +219,7 @@ mailimap_body_fld_param_parse(mailstream * fd,
 
 
 static int
-mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body_type_1part ** result,
 			       size_t progr_rate,
@@ -228,7 +228,7 @@ mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body_type_basic ** result,
 			       size_t progr_rate,
@@ -238,7 +238,7 @@ mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_body_type_mpart_parse(mailstream * fd,
-			       MMAPString * buffer,
+			       MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body_type_mpart ** result,
 			       size_t progr_rate,
@@ -247,7 +247,7 @@ mailimap_body_type_mpart_parse(mailstream * fd,
 
 
 static int
-mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_body_type_msg ** result,
 			     size_t progr_rate,
@@ -256,7 +256,7 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_type_text **
 			      result,
@@ -266,7 +266,7 @@ mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_capability_parse(mailstream * fd, MMAPString * buffer,
+mailimap_capability_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			  size_t * indx,
 			  struct mailimap_capability ** result,
 			  size_t progr_rate,
@@ -285,7 +285,7 @@ static int mailimap_date_day_fixed_parse(mailstream * fd,
 					 size_t * indx,
 					 int * result);
 
-static int mailimap_date_month_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_month_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx, int * result);
 
 /*
@@ -296,27 +296,27 @@ struct mailimap_date_text {
 };
 
 static gboolean
-mailimap_date_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_date_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 guint32 * indx, struct mailimap_date_text ** result);
 static void mailimap_date_text_free(struct mailimap_date_text * date_text);
 */
 
-static int mailimap_date_year_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_year_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, int * result);
 
-static int mailimap_date_time_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_time_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx,
 				    struct mailimap_date_time ** t,
 				    size_t progr_rate,
 				    progress_function * progr_fun);
 
 #ifndef UNSTRICT_SYNTAX
-static int mailimap_digit_nz_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_digit_nz_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, int * result);
 #endif
 
 
-static int mailimap_envelope_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_envelope_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx,
 				   struct mailimap_envelope ** result,
 				   size_t progr_rate,
@@ -324,45 +324,45 @@ static int mailimap_envelope_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_env_bcc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_bcc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx, struct mailimap_env_bcc ** result,
 		       size_t progr_rate,
 		       progress_function * progr_fun);
 
 
 static int
-mailimap_env_cc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_cc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		      size_t * indx, struct mailimap_env_cc ** result,
 		      size_t progr_rate,
 		      progress_function * progr_fun);
 
-static int mailimap_env_date_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_env_date_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, char ** result,
 				   size_t progr_rate,
 				   progress_function * progr_fun);
 
 
 static int
-mailimap_env_from_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_from_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			size_t * indx, struct mailimap_env_from ** result,
 			size_t progr_rate,
 			progress_function * progr_fun);
 
 
 static int mailimap_env_in_reply_to_parse(mailstream * fd,
-					  MMAPString * buffer,
+					  MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					  size_t * indx, char ** result,
 					  size_t progr_rate,
 					  progress_function * progr_fun);
 
 static int mailimap_env_message_id_parse(mailstream * fd,
-					 MMAPString * buffer,
+					 MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					 size_t * indx, char ** result,
 					 size_t progr_rate,
 					 progress_function * progr_fun);
 
 static int
-mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_env_reply_to ** result,
 			    size_t progr_rate,
@@ -371,33 +371,33 @@ mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_env_sender_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_sender_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			  size_t * indx, struct mailimap_env_sender ** result,
 			  size_t progr_rate,
 			  progress_function * progr_fun);
 
-static int mailimap_env_subject_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_env_subject_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				      size_t * indx, char ** result,
 				      size_t progr_rate,
 				      progress_function * progr_fun);
 
 
 static int
-mailimap_env_to_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_to_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		      size_t * indx,
 		      struct mailimap_env_to ** result,
 		      size_t progr_rate,
 		      progress_function * progr_fun);
 
 
-static int mailimap_flag_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_flag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_flag ** result,
 			       size_t progr_rate,
 			       progress_function * progr_fun);
 
 static int mailimap_flag_extension_parse(mailstream * fd,
-					 MMAPString * buffer,
+					 MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					 size_t * indx,
 					 char ** result,
 					 size_t progr_rate,
@@ -407,7 +407,7 @@ static int mailimap_flag_extension_parse(mailstream * fd,
 
 
 static int
-mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer,
+mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			  size_t * indx,
 			  struct mailimap_flag_fetch ** result,
 			  size_t progr_rate,
@@ -416,21 +416,21 @@ mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer,
+mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 size_t * indx,
 			 struct mailimap_flag_perm ** result,
 			 size_t progr_rate,
 			 progress_function * progr_fun);
 
 
-static int mailimap_flag_keyword_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_flag_keyword_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx,
 				       char ** result,
 				       size_t progr_rate,
 				       progress_function * progr_fun);
 
 
-static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx,
 				    struct mailimap_flag_list ** result,
 				    size_t progr_rate,
@@ -439,7 +439,7 @@ static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_header_fld_name_parse(mailstream * fd,
-			       MMAPString * buffer,
+			       MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       char ** result,
 			       size_t progr_rate,
@@ -449,13 +449,13 @@ mailimap_header_fld_name_parse(mailstream * fd,
 
 
 static int
-mailimap_header_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_header_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_header_list ** result,
 			   size_t progr_rate,
 			   progress_function * progr_fun);
 
-static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
+static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                            size_t * indx, char ** result,
                                            size_t * result_len,
                                            size_t progr_rate,
@@ -468,7 +468,7 @@ static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_mailbox_data ** result,
 			    size_t progr_rate,
@@ -476,7 +476,7 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_mbx_list_flags ** result,
 			      size_t progr_rate,
@@ -484,51 +484,51 @@ mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_mbx_list_oflag_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_oflag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_mbx_list_oflag ** result,
 			      size_t progr_rate,
 			      progress_function * progr_fun);
 
 static int
-mailimap_mbx_list_oflag_no_sflag_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_oflag_no_sflag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_mbx_list_oflag ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 static int
-mailimap_mbx_list_sflag_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_sflag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      int * result);
 
 
 static int
-mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_media_basic ** result,
 			   size_t progr_rate,
 			   progress_function * progr_fun);
 
 static int
-mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_message_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx);
 
 static int
-mailimap_media_subtype_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_subtype_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     char ** result,
 			     size_t progr_rate,
 			     progress_function * progr_fun);
 
-static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx,
 				     char ** result,
 				     size_t progr_rate,
 				     progress_function * progr_fun);
 
 static int
-mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                 size_t * indx, struct mailimap_msg_att ** result,
                                 size_t progr_rate,
                                 progress_function * progr_fun,
@@ -540,14 +540,14 @@ mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_msg_att_dynamic ** result,
 			       size_t progr_rate,
 			       progress_function * progr_fun);
 
 static int
-mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                        size_t * indx,
                                        struct mailimap_msg_att_static ** result,
                                        size_t progr_rate,
@@ -559,27 +559,27 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
                                        void * msg_att_context);
 
 static int
-mailimap_quoted_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quoted_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		      size_t * indx, char ** result,
 		      size_t progr_rate,
 		      progress_function * progr_fun);
 
 static int
-mailimap_quoted_specials_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quoted_specials_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, char * result);
 
 
 
 
 static int
-mailimap_response_done_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_done_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_response_done ** result,
 			     size_t progr_rate,
 			     progress_function * progr_fun);
 
 static int
-mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_response_fatal ** result,
 			      size_t progr_rate,
@@ -587,7 +587,7 @@ mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_response_tagged ** result,
 			       size_t progr_rate,
@@ -595,14 +595,14 @@ mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_resp_cond_auth_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_cond_auth_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_resp_cond_auth ** result,
 			      size_t progr_rate,
 			      progress_function * progr_fun);
 
 static int
-mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_resp_cond_bye ** result,
 			     size_t progr_rate,
@@ -610,7 +610,7 @@ mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_resp_cond_state_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_cond_state_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_resp_cond_state ** result,
 			       size_t progr_rate,
@@ -618,7 +618,7 @@ mailimap_resp_cond_state_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 size_t * indx,
 			 struct mailimap_resp_text ** result,
 			 size_t progr_rate,
@@ -626,7 +626,7 @@ mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_resp_text_code ** result,
 			      size_t progr_rate,
@@ -634,7 +634,7 @@ mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_section_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx,
 		       struct mailimap_section ** result,
 		       size_t progr_rate,
@@ -642,7 +642,7 @@ mailimap_section_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_section_msgtext ** result,
 			       size_t progr_rate,
@@ -650,7 +650,7 @@ mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_section_part_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_part_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_section_part ** result,
 			    size_t progr_rate,
@@ -660,7 +660,7 @@ mailimap_section_part_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_section_spec ** result,
 			    size_t progr_rate,
@@ -668,38 +668,38 @@ mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_section_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_section_text ** result,
 			    size_t progr_rate,
 			    progress_function * progr_fun);
 
 
-static int mailimap_tag_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_tag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx, char ** result,
 			      size_t progr_rate,
 			      progress_function * progr_fun);
 
-static int mailimap_text_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, char ** result,
 			       size_t progr_rate,
 			       progress_function * progr_fun);
 
-static int mailimap_time_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_time_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       int * phour, int * pmin, int * psec);
 
-static int mailimap_zone_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_zone_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, int * result);
 
 static int
-mailimap_mailbox_gmail_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_gmail_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, char ** result,
     size_t progr_rate,
     progress_function * progr_fun);
 
 static int
-mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                       size_t * indx,
                                       struct mailimap_response_data ** result,
                                       size_t progr_rate,
@@ -710,7 +710,7 @@ mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
                                       mailimap_msg_att_handler * msg_att_handler,
                                       void * msg_att_context);
 
-static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer,
+static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                            size_t * indx, char ** result,
                                            size_t * result_len,
                                            size_t progr_rate,
@@ -722,7 +722,7 @@ static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer,
                                            void * msg_att_context);
 
 static int
-mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                size_t * indx, char ** result,
                                size_t * result_len,
                                size_t progr_rate,
@@ -735,19 +735,19 @@ mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer,
 
 static int has_crlf(MMAPString * buffer, size_t index);
 
-static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                        size_t * indx,
                                        clist ** result,
                                        size_t progr_rate,
                                        progress_function * progr_fun);
 
-static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
+static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                         size_t * indx,
                                         struct mailimap_envelope ** result,
                                         size_t progr_rate,
                                         progress_function * progr_fun);
 
-static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPString * buffer,
+static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                                       size_t * indx,
                                                       struct mailimap_envelope ** result,
                                                       size_t progr_rate,
@@ -767,7 +767,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
 /* ******************** TOOLS **************************** */
 
 
-static int mailimap_unstrict_char_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_unstrict_char_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					size_t * indx, char token)
 {
   size_t cur_token;
@@ -794,91 +794,91 @@ static int mailimap_unstrict_char_parse(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-int mailimap_oparenth_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_oparenth_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '(');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '(');
 }
 
-int mailimap_cparenth_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_cparenth_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, ')');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, ')');
 }
 
-static int mailimap_oaccolade_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_oaccolade_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '{');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '{');
 }
 
-static int mailimap_caccolade_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_caccolade_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '}');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '}');
 }
 
-static int mailimap_plus_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_plus_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '+');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '+');
 }
 
-static int mailimap_minus_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_minus_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '-');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '-');
 }
 
-static int mailimap_star_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_star_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '*');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '*');
 }
 
-static int mailimap_dot_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_dot_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '.');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '.');
 }
 
-int mailimap_colon_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_colon_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, ':');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, ':');
 }
 
-static int mailimap_lower_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_lower_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '<');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '<');
 }
 
-static int mailimap_greater_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_greater_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '>');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '>');
 }
 
-static int mailimap_obracket_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_obracket_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, '[');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, '[');
 }
 
-static int mailimap_cbracket_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_cbracket_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx)
 {
-  return mailimap_unstrict_char_parse(fd, buffer, indx, ']');
+  return mailimap_unstrict_char_parse(fd, buffer, parser_ctx, indx, ']');
 }
 
-int mailimap_dquote_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_dquote_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx)
 {
   return mailimap_char_parse(fd, buffer, indx, '\"');
 }
 
-static int mailimap_crlf_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_crlf_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx)
 {
   size_t cur_token = * indx;
@@ -895,7 +895,7 @@ static int mailimap_crlf_parse(mailstream * fd, MMAPString * buffer,
   }
 
 #ifdef UNSTRICT_SYNTAX
-  r = mailimap_unstrict_char_parse(fd, buffer, &cur_token, '\n');
+  r = mailimap_unstrict_char_parse(fd, buffer, parser_ctx, &cur_token, '\n');
   if (r == MAILIMAP_NO_ERROR) {
     * indx = cur_token;
     return MAILIMAP_NO_ERROR;
@@ -906,7 +906,7 @@ static int mailimap_crlf_parse(mailstream * fd, MMAPString * buffer,
 }
 
 static int
-mailimap_struct_multiple_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_struct_multiple_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                         size_t * indx, clist ** result,
                                         mailimap_struct_parser_progress * parser,
                                         mailimap_struct_destructor * destructor,
@@ -926,7 +926,7 @@ mailimap_struct_multiple_parse_progress(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
   
-  r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun,
+  r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun,
              body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -950,7 +950,7 @@ mailimap_struct_multiple_parse_progress(mailstream * fd, MMAPString * buffer,
   }
   
   while (1) {
-    r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun,
+    r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun,
                body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
@@ -982,7 +982,7 @@ err:
 }
 
 int
-mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer,
+mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, clist ** result,
 			       mailimap_struct_parser * parser,
 			       mailimap_struct_destructor * destructor,
@@ -997,7 +997,7 @@ mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun);
+  r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -1018,7 +1018,7 @@ mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer,
   }
 
   while (1) {
-    r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun);
+    r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
     if (r != MAILIMAP_NO_ERROR) {
@@ -1047,7 +1047,7 @@ mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer,
 }
 
 int
-mailimap_struct_list_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_struct_list_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                     size_t * indx, clist ** result,
                                     char symbol,
                                     mailimap_struct_parser_progress * parser,
@@ -1070,7 +1070,7 @@ mailimap_struct_list_parse_progress(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   struct_list = NULL;
   
-  r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun,
+  r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun,
              body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -1094,7 +1094,7 @@ mailimap_struct_list_parse_progress(mailstream * fd, MMAPString * buffer,
   final_token = cur_token;
   
   while (1) {
-    r = mailimap_unstrict_char_parse(fd, buffer, &cur_token, symbol);
+    r = mailimap_unstrict_char_parse(fd, buffer, parser_ctx, &cur_token, symbol);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
     if (r != MAILIMAP_NO_ERROR) {
@@ -1102,7 +1102,7 @@ mailimap_struct_list_parse_progress(mailstream * fd, MMAPString * buffer,
       goto free_list;
     }
     
-    r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun,
+    r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun,
                body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
@@ -1135,7 +1135,7 @@ err:
 }
 
 int
-mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx, clist ** result,
 			   char symbol,
 			   mailimap_struct_parser * parser,
@@ -1153,7 +1153,7 @@ mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   struct_list = NULL;
 
-  r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun);
+  r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -1176,7 +1176,7 @@ mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
   final_token = cur_token;
 
   while (1) {
-    r = mailimap_unstrict_char_parse(fd, buffer, &cur_token, symbol);
+    r = mailimap_unstrict_char_parse(fd, buffer, parser_ctx, &cur_token, symbol);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
     if (r != MAILIMAP_NO_ERROR) {
@@ -1184,7 +1184,7 @@ mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
       goto free_list;
     }
 
-    r = parser(fd, buffer, &cur_token, &value, progr_rate, progr_fun);
+    r = parser(fd, buffer, parser_ctx, &cur_token, &value, progr_rate, progr_fun);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
 
@@ -1216,20 +1216,20 @@ mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
 }
 
 int
-mailimap_struct_spaced_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_struct_spaced_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx, clist ** result,
 				  mailimap_struct_parser * parser,
 				  mailimap_struct_destructor * destructor,
 				  size_t progr_rate,
 				  progress_function * progr_fun)
 {
-  return mailimap_struct_list_parse(fd, buffer, indx, result,
+  return mailimap_struct_list_parse(fd, buffer, parser_ctx, indx, result,
 				    ' ', parser, destructor,
 				    progr_rate, progr_fun);
 }
 
 static int
-mailimap_struct_spaced_list_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_struct_spaced_list_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                            size_t * indx, clist ** result,
                                            mailimap_struct_parser_progress * parser,
                                            mailimap_struct_destructor * destructor,
@@ -1241,7 +1241,7 @@ mailimap_struct_spaced_list_parse_progress(mailstream * fd, MMAPString * buffer,
                                            mailimap_msg_att_handler * msg_att_handler,
                                            void * msg_att_context)
 {
-  return mailimap_struct_list_parse_progress(fd, buffer, indx, result,
+  return mailimap_struct_list_parse_progress(fd, buffer, parser_ctx, indx, result,
                                              ' ', parser, destructor,
                                              progr_rate, progr_fun,
                                              body_progr_fun, items_progr_fun, context,
@@ -1250,7 +1250,7 @@ mailimap_struct_spaced_list_parse_progress(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_custom_string_parse(mailstream * fd, MMAPString * buffer,
+mailimap_custom_string_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx, char ** result,
 			     int (* is_custom_char)(char))
 {
@@ -1288,7 +1288,7 @@ mailimap_custom_string_parse(mailstream * fd, MMAPString * buffer,
 
 
 int
-mailimap_nz_number_alloc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_nz_number_alloc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       uint32_t ** result,
 			       size_t progr_rate,
@@ -1301,7 +1301,7 @@ mailimap_nz_number_alloc_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_nz_number_parse(fd, buffer, &cur_token, &number);
+  r = mailimap_nz_number_parse(fd, buffer, parser_ctx, &cur_token, &number);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -1369,7 +1369,7 @@ static int mailimap_digit_parse(mailstream * fd, MMAPString * buffer,
                      addr-host ")"
 */
 
-static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_address_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx,
 				  struct mailimap_address ** result,
 				  size_t progr_rate,
@@ -1391,13 +1391,13 @@ static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
   addr_mailbox = NULL;
   addr_host = NULL;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_addr_name_parse(fd, buffer, &cur_token, &addr_name,
+  r = mailimap_addr_name_parse(fd, buffer, parser_ctx, &cur_token, &addr_name,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -1410,7 +1410,7 @@ static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
     goto addr_name_free;
   }
 
-  r = mailimap_addr_adl_parse(fd, buffer, &cur_token, &addr_adl,
+  r = mailimap_addr_adl_parse(fd, buffer, parser_ctx, &cur_token, &addr_adl,
 			      progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -1423,7 +1423,7 @@ static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
     goto addr_adl_free;
   }
 
-  r = mailimap_addr_mailbox_parse(fd, buffer, &cur_token, &addr_mailbox,
+  r = mailimap_addr_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &addr_mailbox,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -1436,14 +1436,14 @@ static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
     goto addr_mailbox_free;
   }
 
-  r = mailimap_addr_host_parse(fd, buffer, &cur_token, &addr_host,
+  r = mailimap_addr_host_parse(fd, buffer, parser_ctx, &cur_token, &addr_host,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto addr_mailbox_free;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto addr_host_free;
@@ -1479,12 +1479,12 @@ static int mailimap_address_parse(mailstream * fd, MMAPString * buffer,
                        ; non-NIL
 */
 
-static int mailimap_addr_adl_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_adl_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, char ** result,
 				   size_t progr_rate,
 				   progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -1494,7 +1494,7 @@ static int mailimap_addr_adl_parse(mailstream * fd, MMAPString * buffer,
                        ; Otherwise, holds [RFC-822] domain name
 */
 
-static int mailimap_addr_host_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_host_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, char ** result,
 				    size_t progr_rate,
 				    progress_function * progr_fun)
@@ -1507,7 +1507,7 @@ static int mailimap_addr_host_parse(mailstream * fd, MMAPString * buffer,
     return r;
   }
 
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -1520,12 +1520,12 @@ static int mailimap_addr_host_parse(mailstream * fd, MMAPString * buffer,
                        ; after removing [RFC-822] quoting
  */
 
-static int mailimap_addr_mailbox_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_mailbox_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx, char ** result,
 				       size_t progr_rate,
 				       progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -1536,12 +1536,12 @@ static int mailimap_addr_mailbox_parse(mailstream * fd, MMAPString * buffer,
                        ; mailbox after removing [RFC-822] quoting
 */
 
-static int mailimap_addr_name_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_addr_name_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, char ** result,
 				    size_t progr_rate,
 				    progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -1559,17 +1559,17 @@ static int mailimap_addr_name_parse(mailstream * fd, MMAPString * buffer,
 static int is_astring_char(char ch);
 
 static int
-mailimap_atom_astring_parse(mailstream * fd, MMAPString * buffer,
+mailimap_atom_astring_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx, char ** result,
 			    size_t progr_rate,
 			    progress_function * progr_fun)
 {
-  return mailimap_custom_string_parse(fd, buffer, indx, result,
+  return mailimap_custom_string_parse(fd, buffer, parser_ctx, indx, result,
 				      is_astring_char);
 }
 
 int
-mailimap_astring_parse(mailstream * fd, MMAPString * buffer,
+mailimap_astring_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx,
 		       char ** result,
 		       size_t progr_rate,
@@ -1581,14 +1581,14 @@ mailimap_astring_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_atom_astring_parse(fd, buffer, &cur_token, &astring,
+  r = mailimap_atom_astring_parse(fd, buffer, parser_ctx, &cur_token, &astring,
 				  progr_rate, progr_fun);
   switch (r) {
   case MAILIMAP_NO_ERROR:
     break;
 
   case MAILIMAP_ERROR_PARSE:
-    r = mailimap_string_parse(fd, buffer, &cur_token, &astring, NULL,
+    r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &astring, NULL,
 			      progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR)
       return r;
@@ -1624,12 +1624,12 @@ static int is_astring_char(char ch)
    atom            = 1*ATOM-CHAR
 */
 
-int mailimap_atom_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_atom_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			size_t * indx, char ** result,
 			size_t progr_rate,
 			progress_function * progr_fun)
 {
-  return mailimap_custom_string_parse(fd, buffer, indx, result,
+  return mailimap_custom_string_parse(fd, buffer, parser_ctx, indx, result,
 				      is_atom_char);
 }
 
@@ -1686,12 +1686,12 @@ static int is_atom_specials(char ch)
                        ; Defined by [SASL]
 */
 
-static int mailimap_auth_type_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_auth_type_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, char ** result,
 				    size_t progr_rate,
 				    progress_function * progr_fun)
 {
-  return mailimap_atom_parse(fd, buffer, indx, result,
+  return mailimap_atom_parse(fd, buffer, parser_ctx, indx, result,
 			     progr_rate, progr_fun);
 }
 
@@ -1702,7 +1702,7 @@ static int mailimap_auth_type_parse(mailstream * fd, MMAPString * buffer,
 static int is_base64_4char(char * str);
 static int is_base64_terminal(char * str);
 
-static int mailimap_base64_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_base64_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx, char ** result,
 				 size_t progr_rate,
 				 progress_function * progr_fun)
@@ -1783,7 +1783,7 @@ static int is_base64_terminal(char * str)
    body            = "(" (body-type-1part / body-type-mpart) ")"
 */
 
-static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body ** result,
 			       size_t progr_rate,
@@ -1802,7 +1802,7 @@ static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
   body_type_1part = NULL;
   body_type_mpart = NULL;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -1810,13 +1810,13 @@ static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_BODY_ERROR; /* XXX - removes a gcc warning */
 
-  r = mailimap_body_type_1part_parse(fd, buffer, &cur_token, &body_type_1part,
+  r = mailimap_body_type_1part_parse(fd, buffer, parser_ctx, &cur_token, &body_type_1part,
 				     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_BODY_1PART;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-   r = mailimap_body_type_mpart_parse(fd, buffer, &cur_token,
+   r = mailimap_body_type_mpart_parse(fd, buffer, parser_ctx, &cur_token,
 				      &body_type_mpart,
 				      progr_rate, progr_fun);
    
@@ -1829,7 +1829,7 @@ static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -1871,7 +1871,7 @@ static int mailimap_body_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     clist ** result,
 			     size_t progr_rate,
@@ -1884,13 +1884,13 @@ mailimap_body_ext_list_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
 					&cur_token, &list,
 					(mailimap_struct_parser * )
 					mailimap_body_extension_parse,
@@ -1902,7 +1902,7 @@ mailimap_body_ext_list_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
   
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_list;
@@ -1932,7 +1932,7 @@ mailimap_body_ext_list_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_extension ** result,
 			      size_t progr_rate,
@@ -1954,7 +1954,7 @@ mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer,
   body_extension_list = NULL;
   type = MAILIMAP_BODY_EXTENSION_ERROR; /* XXX - removes a gcc warning */
 
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &nstring, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &nstring, NULL,
 			     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_BODY_EXTENSION_NSTRING;
@@ -1967,7 +1967,7 @@ mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_body_ext_list_parse(fd, buffer, &cur_token,
+    r = mailimap_body_ext_list_parse(fd, buffer, parser_ctx, &cur_token,
 				     &body_extension_list,
 				     progr_rate, progr_fun);
 
@@ -2018,7 +2018,7 @@ mailimap_body_extension_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_1part_4_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_1part_4_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx,
 				clist ** body_ext_list,
 				size_t progr_rate,
@@ -2034,7 +2034,7 @@ mailimap_body_ext_1part_4_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token,
 					body_ext_list,
 					(mailimap_struct_parser *)
 					mailimap_body_extension_parse,
@@ -2054,7 +2054,7 @@ mailimap_body_ext_1part_4_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_1part_3_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_1part_3_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                 size_t * indx,
                                 char ** fld_loc,
                                 clist ** body_ext_list,
@@ -2072,12 +2072,12 @@ mailimap_body_ext_1part_3_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_body_fld_loc_parse(fd, buffer, &cur_token, fld_loc,
+  r = mailimap_body_fld_loc_parse(fd, buffer, parser_ctx, &cur_token, fld_loc,
                                   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_body_ext_1part_4_parse(fd, buffer, &cur_token,
+  r = mailimap_body_ext_1part_4_parse(fd, buffer, parser_ctx, &cur_token,
                                       body_ext_list, progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE))
     return r;
@@ -2093,7 +2093,7 @@ mailimap_body_ext_1part_3_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_1part_2_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_1part_2_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx,
 				struct mailimap_body_fld_lang ** fld_lang,
         char ** fld_loc,
@@ -2113,12 +2113,12 @@ mailimap_body_ext_1part_2_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_body_fld_lang_parse(fd, buffer, &cur_token, fld_lang,
+  r = mailimap_body_fld_lang_parse(fd, buffer, parser_ctx, &cur_token, fld_lang,
 				   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_body_ext_1part_3_parse(fd, buffer, &cur_token,
+  r = mailimap_body_ext_1part_3_parse(fd, buffer, parser_ctx, &cur_token,
 				      fld_loc, body_ext_list, progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE))
     return r;
@@ -2135,7 +2135,7 @@ mailimap_body_ext_1part_2_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_1part_1_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_1part_1_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx,
 				struct mailimap_body_fld_dsp ** fld_dsp,
 				struct mailimap_body_fld_lang ** fld_lang,
@@ -2157,12 +2157,12 @@ mailimap_body_ext_1part_1_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_body_fld_dsp_parse(fd, buffer, &cur_token, fld_dsp,
+  r = mailimap_body_fld_dsp_parse(fd, buffer, parser_ctx, &cur_token, fld_dsp,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_body_ext_1part_2_parse(fd, buffer, &cur_token,
+  r = mailimap_body_ext_1part_2_parse(fd, buffer, parser_ctx, &cur_token,
 				      fld_lang, fld_loc, body_ext_list,
 				      progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE))
@@ -2181,7 +2181,7 @@ mailimap_body_ext_1part_1_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_ext_1part ** result,
 			      size_t progr_rate,
@@ -2207,14 +2207,14 @@ mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer,
   fld_loc = NULL;
   body_ext_list = NULL;
 
-  r = mailimap_body_fld_md5_parse(fd, buffer, &cur_token, &fld_md5,
+  r = mailimap_body_fld_md5_parse(fd, buffer, parser_ctx, &cur_token, &fld_md5,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_body_ext_1part_1_parse(fd, buffer, &cur_token,
+  r = mailimap_body_ext_1part_1_parse(fd, buffer, parser_ctx, &cur_token,
 				      &fld_dsp,
 				      &fld_lang,
               &fld_loc,
@@ -2263,7 +2263,7 @@ mailimap_body_ext_1part_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_ext_mpart ** result,
 			      size_t progr_rate,
@@ -2289,14 +2289,14 @@ mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer,
   fld_loc = NULL;
   body_ext_list = NULL;
 
-  r = mailimap_body_fld_param_parse(fd, buffer, &cur_token, &fld_param,
+  r = mailimap_body_fld_param_parse(fd, buffer, parser_ctx, &cur_token, &fld_param,
 				    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_body_ext_1part_1_parse(fd, buffer, &cur_token,
+  r = mailimap_body_ext_1part_1_parse(fd, buffer, parser_ctx, &cur_token,
 				      &fld_dsp,
 				      &fld_lang,
               &fld_loc,
@@ -2342,7 +2342,7 @@ mailimap_body_ext_mpart_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_body_fields ** result,
 			   size_t progr_rate,
@@ -2366,7 +2366,7 @@ mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_body_fld_param_parse(fd, buffer, &cur_token, &body_fld_param,
+  r = mailimap_body_fld_param_parse(fd, buffer, parser_ctx, &cur_token, &body_fld_param,
 				    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -2379,7 +2379,7 @@ mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
     goto fld_param_free;
   }
 
-  r = mailimap_body_fld_id_parse(fd, buffer, &cur_token, &body_fld_id,
+  r = mailimap_body_fld_id_parse(fd, buffer, parser_ctx, &cur_token, &body_fld_id,
 				 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -2392,7 +2392,7 @@ mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
     goto fld_id_free;
   }
   
-  r = mailimap_body_fld_desc_parse(fd, buffer, &cur_token, &body_fld_desc,
+  r = mailimap_body_fld_desc_parse(fd, buffer, parser_ctx, &cur_token, &body_fld_desc,
 				   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -2405,7 +2405,7 @@ mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
     goto fld_desc_free;
   }
   
-  r = mailimap_body_fld_enc_parse(fd, buffer, &cur_token, &body_fld_enc,
+  r = mailimap_body_fld_enc_parse(fd, buffer, parser_ctx, &cur_token, &body_fld_enc,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -2418,7 +2418,7 @@ mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
     goto fld_enc_free;
   }
 
-  r = mailimap_body_fld_octets_parse(fd, buffer, &cur_token,
+  r = mailimap_body_fld_octets_parse(fd, buffer, parser_ctx, &cur_token,
 				     &body_fld_octets);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -2457,12 +2457,12 @@ mailimap_body_fields_parse(mailstream * fd, MMAPString * buffer,
    body-fld-desc   = nstring
 */
 
-static int mailimap_body_fld_desc_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_desc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					size_t * indx, char ** result,
 					size_t progr_rate,
 					progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -2471,7 +2471,7 @@ static int mailimap_body_fld_desc_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_body_fld_dsp ** result,
 			    size_t progr_rate,
@@ -2488,7 +2488,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
   name = NULL;
   body_fld_param = NULL;
 
-  r = mailimap_nil_parse(fd, buffer, &cur_token);
+  r = mailimap_nil_parse(fd, buffer, parser_ctx, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
     * result = NULL;
     * indx = cur_token;
@@ -2500,10 +2500,10 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     // workaround for exchange
-    r = mailimap_string_parse(fd, buffer, &cur_token, &name, NULL,
+    r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &name, NULL,
                               +                                progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -2516,7 +2516,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
       goto string_free;
     }
     
-    r = mailimap_body_fld_param_parse(fd, buffer, &cur_token,
+    r = mailimap_body_fld_param_parse(fd, buffer, parser_ctx, &cur_token,
                                       &body_fld_param,
                                       progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
@@ -2527,7 +2527,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
     goto create_body_fld_dsp;
   }
 
-  r = mailimap_string_parse(fd, buffer, &cur_token, &name, NULL,
+  r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &name, NULL,
 			    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -2537,7 +2537,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
   r = mailimap_space_parse(fd, buffer, &cur_token);
   /* workaround for IMAPrev1 Citadel */
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto string_free;
@@ -2553,7 +2553,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
     goto string_free;
   }
 
-  r = mailimap_body_fld_param_parse(fd, buffer, &cur_token,
+  r = mailimap_body_fld_param_parse(fd, buffer, parser_ctx, &cur_token,
 				    &body_fld_param,
 				    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
@@ -2561,7 +2561,7 @@ mailimap_body_fld_dsp_parse(mailstream * fd, MMAPString * buffer,
     goto string_free;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto string_free;
@@ -2594,7 +2594,7 @@ create_body_fld_dsp:
 */
 
 static inline int 
-mailimap_body_fld_known_enc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_known_enc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     int * result,
     size_t progr_rate,
@@ -2607,7 +2607,7 @@ mailimap_body_fld_known_enc_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r == MAILIMAP_ERROR_PARSE) {
     /* workaround for exchange */
     type = mailimap_encoding_get_token_value(fd, buffer, &cur_token);
@@ -2634,7 +2634,7 @@ mailimap_body_fld_known_enc_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
   
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -2650,7 +2650,7 @@ mailimap_body_fld_known_enc_parse(mailstream * fd, MMAPString * buffer,
 }     
 
 static int
-mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_body_fld_enc ** result,
 			    size_t progr_rate,
@@ -2665,7 +2665,7 @@ mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_body_fld_known_enc_parse(fd, buffer, &cur_token,
+  r = mailimap_body_fld_known_enc_parse(fd, buffer, parser_ctx, &cur_token,
       &type, progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     value = NULL;
@@ -2673,11 +2673,11 @@ mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer,
   else if (r == MAILIMAP_ERROR_PARSE) {
     type = MAILIMAP_BODY_FLD_ENC_OTHER;
 
-    r = mailimap_nstring_parse(fd, buffer, &cur_token, &value, NULL,
+    r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &value, NULL,
 			      progr_rate, progr_fun);
     if (r == MAILIMAP_ERROR_PARSE) {
       /* workaround for exchange */
-      r = mailimap_astring_parse(fd, buffer, &cur_token, &value,
+      r = mailimap_astring_parse(fd, buffer, parser_ctx, &cur_token, &value,
                                  progr_rate, progr_fun);
     }
     
@@ -2717,19 +2717,19 @@ mailimap_body_fld_enc_parse(mailstream * fd, MMAPString * buffer,
    body-fld-id     = nstring
 */
 
-static int mailimap_body_fld_id_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_id_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				      size_t * indx, char ** result,
 				      size_t progr_rate,
 				      progress_function * progr_fun)
 {
   int r;
   
-  r = mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
                              progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     return MAILIMAP_NO_ERROR;
   
-  r = mailimap_atom_parse(fd, buffer, indx, result,
+  r = mailimap_atom_parse(fd, buffer, parser_ctx, indx, result,
                           progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     return MAILIMAP_NO_ERROR;
@@ -2747,7 +2747,7 @@ static int mailimap_body_fld_id_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_fld_lang_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_lang_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx, clist ** result,
 				  size_t progr_rate,
 				  progress_function * progr_fun)
@@ -2759,7 +2759,7 @@ mailimap_body_fld_lang_list_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -2776,7 +2776,7 @@ mailimap_body_fld_lang_list_parse(mailstream * fd, MMAPString * buffer,
 
     mailimap_space_parse(fd, buffer, &cur_token);
     
-    r = mailimap_string_parse(fd, buffer, &cur_token, &elt, NULL,
+    r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &elt, NULL,
 			      progr_rate, progr_fun);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
@@ -2794,7 +2794,7 @@ mailimap_body_fld_lang_list_parse(mailstream * fd, MMAPString * buffer,
     }
   }
   
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto list_free;
@@ -2817,7 +2817,7 @@ mailimap_body_fld_lang_list_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_fld_lang_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_fld_lang_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_body_fld_lang ** result,
 			     size_t progr_rate,
@@ -2838,13 +2838,13 @@ mailimap_body_fld_lang_parse(mailstream * fd, MMAPString * buffer,
   list = NULL;
   type = MAILIMAP_BODY_FLD_LANG_ERROR; /* XXX - removes a gcc warning */
   
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &value, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &value, NULL,
 			     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_BODY_FLD_LANG_SINGLE;
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_body_fld_lang_list_parse(fd, buffer, &cur_token, &list,
+    r = mailimap_body_fld_lang_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 					  progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_BODY_FLD_LANG_LIST;
@@ -2882,7 +2882,7 @@ mailimap_body_fld_lang_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int mailimap_body_fld_lines_parse(mailstream * fd,
-					 MMAPString * buffer, size_t * indx,
+					 MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 					 uint32_t * result)
 {
   return mailimap_number_parse(fd, buffer, indx, result);
@@ -2892,7 +2892,7 @@ static int mailimap_body_fld_lines_parse(mailstream * fd,
    body-fld-md5    = nstring
 */
 
-static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx, char ** result,
 				       size_t progr_rate,
 				       progress_function * progr_fun)
@@ -2902,7 +2902,7 @@ static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer,
   size_t cur_token;
   char * md5_value;
   
-  r = mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
       progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     return r;
@@ -2919,7 +2919,7 @@ static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer,
     return r;
   }
 
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &md5_value, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &md5_value, NULL,
       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
@@ -2931,12 +2931,12 @@ static int mailimap_body_fld_md5_parse(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-static int mailimap_body_fld_loc_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_body_fld_loc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                        size_t * indx, char ** result,
                                        size_t progr_rate,
                                        progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
                                 progr_rate, progr_fun);
 }
 
@@ -2945,7 +2945,7 @@ static int mailimap_body_fld_loc_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int mailimap_body_fld_octets_parse(mailstream * fd,
-					  MMAPString * buffer, size_t * indx,
+					  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 					  uint32_t * result)
 {
   int r;
@@ -2962,7 +2962,7 @@ static int mailimap_body_fld_octets_parse(mailstream * fd,
   }
   
   // workaround for mbox mail for mac
-  r = mailimap_nil_parse(fd, buffer, indx);
+  r = mailimap_nil_parse(fd, buffer, parser_ctx, indx);
   if (r == MAILIMAP_NO_ERROR) {
     * result = 0;
     return MAILIMAP_NO_ERROR;
@@ -2980,7 +2980,7 @@ static int mailimap_body_fld_octets_parse(mailstream * fd,
 */
 
 static int
-mailimap_single_body_fld_param_parse(mailstream * fd, MMAPString * buffer,
+mailimap_single_body_fld_param_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx,
 				     struct mailimap_single_body_fld_param **
 				     result,
@@ -3000,10 +3000,10 @@ mailimap_single_body_fld_param_parse(mailstream * fd, MMAPString * buffer,
   name = NULL;
   value = NULL;
 
-  r = mailimap_string_parse(fd, buffer, &cur_token, &name, NULL,
+  r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &name, NULL,
 			    progr_rate, progr_fun);
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_astring_parse(fd, buffer, &cur_token, &name,
+    r = mailimap_astring_parse(fd, buffer, parser_ctx, &cur_token, &name,
                                progr_rate, progr_fun);
   }
   if (r != MAILIMAP_NO_ERROR) {
@@ -3030,7 +3030,7 @@ mailimap_single_body_fld_param_parse(mailstream * fd, MMAPString * buffer,
   
   if (!workaround_used) {
 	  // also parse NIL to workaround Exchange issue
-    r = mailimap_nstring_parse(fd, buffer, &cur_token, &value, NULL,
+    r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &value, NULL,
                               progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -3071,7 +3071,7 @@ static void mailimap_broken_single_body_fld_param_string_free(char * value)
 }
 
 static int
-mailimap_broken_single_body_fld_param_string_parse(mailstream * fd, MMAPString * buffer,
+mailimap_broken_single_body_fld_param_string_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                                    size_t * indx,
                                                    char ** result,
                                                    size_t progr_rate,
@@ -3083,7 +3083,7 @@ mailimap_broken_single_body_fld_param_string_parse(mailstream * fd, MMAPString *
   
   cur_token = * indx;
   
-  r = mailimap_string_parse(fd, buffer, &cur_token, &value, NULL,
+  r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &value, NULL,
                             progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     mailimap_string_free(value);
@@ -3092,7 +3092,7 @@ mailimap_broken_single_body_fld_param_string_parse(mailstream * fd, MMAPString *
     return r;
   }
   
-  r = mailimap_astring_parse(fd, buffer, &cur_token, &value,
+  r = mailimap_astring_parse(fd, buffer, parser_ctx, &cur_token, &value,
                              progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     mailimap_astring_free(value);
@@ -3108,7 +3108,7 @@ mailimap_broken_single_body_fld_param_string_parse(mailstream * fd, MMAPString *
     return r;
   }
   
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &value, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &value, NULL,
                              progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     mailimap_nstring_free(value);
@@ -3126,7 +3126,7 @@ mailimap_broken_single_body_fld_param_string_parse(mailstream * fd, MMAPString *
 
 static int
 mailimap_body_fld_param_parse(mailstream * fd,
-			      MMAPString * buffer, size_t * indx,
+			      MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 			      struct mailimap_body_fld_param ** result,
 			      size_t progr_rate,
 			      progress_function * progr_fun)
@@ -3140,7 +3140,7 @@ mailimap_body_fld_param_parse(mailstream * fd,
   param_list = NULL;
   cur_token = * indx;
 
-  r = mailimap_nil_parse(fd, buffer, &cur_token);
+  r = mailimap_nil_parse(fd, buffer, parser_ctx, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
     * result = NULL;
     * indx = cur_token;
@@ -3152,13 +3152,13 @@ mailimap_body_fld_param_parse(mailstream * fd,
     goto err;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &param_list,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &param_list,
 					(mailimap_struct_parser *)
 					mailimap_single_body_fld_param_parse,
 					(mailimap_struct_destructor *)
@@ -3173,7 +3173,7 @@ mailimap_body_fld_param_parse(mailstream * fd,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r == MAILIMAP_ERROR_PARSE) {
     // workaround for broken param list
     if (param_list != NULL) {
@@ -3183,7 +3183,7 @@ mailimap_body_fld_param_parse(mailstream * fd,
       clist_free(param_list);
       param_list = NULL;
     }
-    r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &param_list,
+    r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &param_list,
                                           (mailimap_struct_parser *)
                                           mailimap_broken_single_body_fld_param_string_parse,
                                           (mailimap_struct_destructor *)
@@ -3198,7 +3198,7 @@ mailimap_body_fld_param_parse(mailstream * fd,
       goto free;
     }
     
-    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto free;
@@ -3244,7 +3244,7 @@ mailimap_body_fld_param_parse(mailstream * fd,
 */
 
 static int
-mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body_type_1part ** result,
 			       size_t progr_rate,
@@ -3270,14 +3270,14 @@ mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
   
   type = MAILIMAP_BODY_TYPE_1PART_ERROR; /* XXX - removes a gcc warning */
   
-  r = mailimap_body_type_msg_parse(fd, buffer, &cur_token,
+  r = mailimap_body_type_msg_parse(fd, buffer, parser_ctx, &cur_token,
 				   &body_type_msg,
 				   progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_BODY_TYPE_1PART_MSG;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_body_type_text_parse(fd, buffer, &cur_token,
+    r = mailimap_body_type_text_parse(fd, buffer, parser_ctx, &cur_token,
 				      &body_type_text,
 				      progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -3285,7 +3285,7 @@ mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_body_type_basic_parse(fd, buffer, &cur_token,
+    r = mailimap_body_type_basic_parse(fd, buffer, parser_ctx, &cur_token,
 				       &body_type_basic,
 				       progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -3303,7 +3303,7 @@ mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
   r = mailimap_space_parse(fd, buffer, &cur_token);
 
   if (r == MAILIMAP_NO_ERROR) {
-    r = mailimap_body_ext_1part_parse(fd, buffer, &cur_token, &body_ext_1part,
+    r = mailimap_body_ext_1part_parse(fd, buffer, parser_ctx, &cur_token, &body_ext_1part,
 				      progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       final_token = cur_token;
@@ -3355,7 +3355,7 @@ mailimap_body_type_1part_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body_type_basic ** result,
 			       size_t progr_rate,
@@ -3375,7 +3375,7 @@ mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
   media_basic = NULL;
   body_fields = NULL;
 
-  r = mailimap_media_basic_parse(fd, buffer, &cur_token, &media_basic,
+  r = mailimap_media_basic_parse(fd, buffer, parser_ctx, &cur_token, &media_basic,
 				 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3388,7 +3388,7 @@ mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
     goto free_media_basic;
   }
 
-  r = mailimap_body_fields_parse(fd, buffer, &cur_token, &body_fields,
+  r = mailimap_body_fields_parse(fd, buffer, parser_ctx, &cur_token, &body_fields,
 				 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3400,7 +3400,7 @@ mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
   
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
-    r = mailimap_body_fld_lines_parse(fd, buffer, &cur_token, &body_fld_lines);
+    r = mailimap_body_fld_lines_parse(fd, buffer, parser_ctx, &cur_token, &body_fld_lines);
     if (r != MAILIMAP_NO_ERROR) {
       cur_token = saved_token;
     }
@@ -3436,7 +3436,7 @@ mailimap_body_type_basic_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_body_type_mpart_parse(mailstream * fd,
-			       MMAPString * buffer,
+			       MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_body_type_mpart ** result,
 			       size_t progr_rate,
@@ -3457,7 +3457,7 @@ mailimap_body_type_mpart_parse(mailstream * fd,
   media_subtype = NULL;
   body_ext_mpart = NULL;
 
-  r = mailimap_struct_multiple_parse(fd, buffer, &cur_token,
+  r = mailimap_struct_multiple_parse(fd, buffer, parser_ctx, &cur_token,
 				     &body_list,
 				     (mailimap_struct_parser *)
 				     mailimap_body_parse,
@@ -3483,7 +3483,7 @@ mailimap_body_type_mpart_parse(mailstream * fd,
     }
   }
 
-  r = mailimap_media_subtype_parse(fd, buffer, &cur_token, &media_subtype,
+  r = mailimap_media_subtype_parse(fd, buffer, parser_ctx, &cur_token, &media_subtype,
 				   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3496,7 +3496,7 @@ mailimap_body_type_mpart_parse(mailstream * fd,
 
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
-    r = mailimap_body_ext_mpart_parse(fd, buffer, &cur_token, &body_ext_mpart,
+    r = mailimap_body_ext_mpart_parse(fd, buffer, parser_ctx, &cur_token, &body_ext_mpart,
 				      progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       final_token = cur_token;
@@ -3595,7 +3595,7 @@ static struct mailimap_body * body_text_new_empty(void)
 }
 
 static int
-mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_body_type_msg ** result,
 			     size_t progr_rate,
@@ -3617,7 +3617,7 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
   body = NULL;
   body_fld_lines = 0;
 
-  r = mailimap_media_message_parse(fd, buffer, &cur_token);
+  r = mailimap_media_message_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -3629,7 +3629,7 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_body_fields_parse(fd, buffer, &cur_token, &body_fields,
+  r = mailimap_body_fields_parse(fd, buffer, parser_ctx, &cur_token, &body_fields,
 				 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3642,7 +3642,7 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
     goto body_fields;
   }
 
-  r = mailimap_envelope_parse(fd, buffer, &cur_token, &envelope,
+  r = mailimap_envelope_parse(fd, buffer, parser_ctx, &cur_token, &envelope,
 			      progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3658,16 +3658,16 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
     goto envelope;
   }
 
-  r = mailimap_body_parse(fd, buffer, &cur_token, &body,
+  r = mailimap_body_parse(fd, buffer, parser_ctx, &cur_token, &body,
 			  progr_rate, progr_fun);
   if (r == MAILIMAP_ERROR_PARSE) {
 	  /* workaround for Lotus Domino - body malformed */
-    r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = MAILIMAP_ERROR_PARSE;
       goto envelope;
     }
-    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = MAILIMAP_ERROR_PARSE;
       goto envelope;
@@ -3690,7 +3690,7 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
     goto body;
   }
 
-  r = mailimap_body_fld_lines_parse(fd, buffer, &cur_token,
+  r = mailimap_body_fld_lines_parse(fd, buffer, parser_ctx, &cur_token,
 				    &body_fld_lines);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3724,7 +3724,7 @@ mailimap_body_type_msg_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_body_type_text **
 			      result,
@@ -3745,7 +3745,7 @@ mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
 
-  r = mailimap_media_text_parse(fd, buffer, &cur_token, &media_text,
+  r = mailimap_media_text_parse(fd, buffer, parser_ctx, &cur_token, &media_text,
 				progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3758,7 +3758,7 @@ mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
     goto free_media_text;
   }
 
-  r = mailimap_body_fields_parse(fd, buffer, &cur_token, &body_fields,
+  r = mailimap_body_fields_parse(fd, buffer, parser_ctx, &cur_token, &body_fields,
 				 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -3771,7 +3771,7 @@ mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
     goto free_body_fields;
   }
 
-  r = mailimap_body_fld_lines_parse(fd, buffer, &cur_token, &body_fld_lines);
+  r = mailimap_body_fld_lines_parse(fd, buffer, parser_ctx, &cur_token, &body_fld_lines);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_body_fields;
@@ -3806,7 +3806,7 @@ mailimap_body_type_text_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_capability_parse(mailstream * fd, MMAPString * buffer,
+mailimap_capability_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			  size_t * indx,
 			  struct mailimap_capability ** result,
 			  size_t progr_rate,
@@ -3830,7 +3830,7 @@ mailimap_capability_parse(mailstream * fd, MMAPString * buffer,
   case MAILIMAP_NO_ERROR:
     type = MAILIMAP_CAPABILITY_AUTH_TYPE;
 
-    r = mailimap_auth_type_parse(fd, buffer, &cur_token, &auth_type,
+    r = mailimap_auth_type_parse(fd, buffer, parser_ctx, &cur_token, &auth_type,
 				 progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -3839,7 +3839,7 @@ mailimap_capability_parse(mailstream * fd, MMAPString * buffer,
     break;
 
   case MAILIMAP_ERROR_PARSE:
-    r = mailimap_atom_parse(fd, buffer, &cur_token, &atom,
+    r = mailimap_atom_parse(fd, buffer, parser_ctx, &cur_token, &atom,
 			    progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -3887,7 +3887,7 @@ mailimap_capability_parse(mailstream * fd, MMAPString * buffer,
 */
 
 int mailimap_capability_list_parse(mailstream * fd,
-					  MMAPString * buffer,
+					  MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					  size_t * indx,
 					  clist ** result,
 					  size_t progr_rate,
@@ -3903,7 +3903,7 @@ int mailimap_capability_list_parse(mailstream * fd,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 					(mailimap_struct_parser *)
 					mailimap_capability_parse,
 					(mailimap_struct_destructor *)
@@ -3919,7 +3919,7 @@ int mailimap_capability_list_parse(mailstream * fd,
 }
 
 int
-mailimap_capability_data_parse(mailstream * fd, MMAPString * buffer,
+mailimap_capability_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_capability_data ** result,
 			       size_t progr_rate,
@@ -3941,7 +3941,7 @@ mailimap_capability_data_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_capability_list_parse(fd, buffer, &cur_token,
+  r = mailimap_capability_list_parse(fd, buffer, parser_ctx, &cur_token,
 				     &cap_list,
 				     progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE)) {
@@ -4021,7 +4021,7 @@ UNIMPLEMENTED
 */
 
 int
-mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer,
+mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_continue_req ** result,
 			    size_t progr_rate,
@@ -4038,7 +4038,7 @@ mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
   
-  r = mailimap_plus_parse(fd, buffer, &cur_token);
+  r = mailimap_plus_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -4056,13 +4056,13 @@ mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer,
   type = MAILIMAP_CONTINUE_REQ_ERROR; /* XXX - removes a gcc warning */
   
   saved_token = cur_token;
-  r = mailimap_base64_parse(fd, buffer, &cur_token, &base64,
+  r = mailimap_base64_parse(fd, buffer, parser_ctx, &cur_token, &base64,
       progr_rate, progr_fun);
 
   if (r == MAILIMAP_NO_ERROR) {
     type = MAILIMAP_CONTINUE_REQ_BASE64;
     
-    r = mailimap_crlf_parse(fd, buffer, &cur_token);
+    r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
     if (r == MAILIMAP_NO_ERROR) {
       /* do nothing */
     }
@@ -4078,13 +4078,13 @@ mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer,
   }
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_resp_text_parse(fd, buffer, &cur_token, &resp_text,
+    r = mailimap_resp_text_parse(fd, buffer, parser_ctx, &cur_token, &resp_text,
         progr_rate, progr_fun);
     
     if (r == MAILIMAP_NO_ERROR) {
       type = MAILIMAP_CONTINUE_REQ_TEXT;
       
-      r = mailimap_crlf_parse(fd, buffer, &cur_token);
+      r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
       if (r == MAILIMAP_NO_ERROR) {
         /* do nothing */
       }
@@ -4244,7 +4244,7 @@ static int mailimap_date_day_fixed_parse(mailstream * fd,
                      "Jul" / "Aug" / "Sep" / "Oct" / "Nov" / "Dec"
 */
 
-static int mailimap_date_month_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_month_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx, int * result)
 {
   size_t cur_token;
@@ -4290,7 +4290,7 @@ static void mailimap_date_text_free(struct mailimap_date_text * date_text)
 }
 
 static gboolean
-mailimap_date_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_date_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 guint32 * indx, struct mailimap_date_text ** result)
 {
   struct mailimap_date_text * date_text;
@@ -4301,19 +4301,19 @@ mailimap_date_text_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  if (!mailimap_date_day_parse(fd, buffer, &cur_token, &day))
+  if (!mailimap_date_day_parse(fd, buffer, parser_ctx, &cur_token, &day))
     return FALSE;
 
-  if (!mailimap_minus_parse(fd, buffer, &cur_token))
+  if (!mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token))
     return FALSE;
 
-  if (!mailimap_date_month_parse(fd, buffer, &cur_token, &month))
+  if (!mailimap_date_month_parse(fd, buffer, parser_ctx, &cur_token, &month))
     return FALSE;
 
-  if (!mailimap_minus_parse(fd, buffer, &cur_token))
+  if (!mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token))
     return FALSE;
 
-  if (!mailimap_date_year_parse(fd, buffer, &cur_token, &year))
+  if (!mailimap_date_year_parse(fd, buffer, parser_ctx, &cur_token, &year))
     return FALSE;
 
   date_text = mailimap_date_text_new(day, month, year);
@@ -4331,7 +4331,7 @@ mailimap_date_text_parse(mailstream * fd, MMAPString * buffer,
    date-year       = 4DIGIT
 */
 
-static int mailimap_date_year_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_year_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx, int * result)
 {
 #ifdef UNSTRICT_SYNTAX
@@ -4398,7 +4398,7 @@ static int get_current_timezone_offset(void)
   return off;
 }
 
-static int mailimap_date_time_no_quote_space_timezone_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_time_no_quote_space_timezone_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                                             size_t * indx, int * p_timezone)
 {
   int r;
@@ -4411,7 +4411,7 @@ static int mailimap_date_time_no_quote_space_timezone_parse(mailstream * fd, MMA
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_zone_parse(fd, buffer, &cur_token, &zone);
+  r = mailimap_zone_parse(fd, buffer, parser_ctx, &cur_token, &zone);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
@@ -4421,7 +4421,7 @@ static int mailimap_date_time_no_quote_space_timezone_parse(mailstream * fd, MMA
   return MAILIMAP_NO_ERROR;
 }
 
-static int mailimap_date_time_no_quote_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_time_no_quote_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                              size_t * indx,
                                              struct mailimap_date_time ** result,
                                              size_t progr_rate,
@@ -4444,19 +4444,19 @@ static int mailimap_date_time_no_quote_parse(mailstream * fd, MMAPString * buffe
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_minus_parse(fd, buffer, &cur_token);
+  r = mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_date_month_parse(fd, buffer, &cur_token, &month);
+  r = mailimap_date_month_parse(fd, buffer, parser_ctx, &cur_token, &month);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_minus_parse(fd, buffer, &cur_token);
+  r = mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_date_year_parse(fd, buffer, &cur_token, &year);
+  r = mailimap_date_year_parse(fd, buffer, parser_ctx, &cur_token, &year);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
@@ -4464,11 +4464,11 @@ static int mailimap_date_time_no_quote_parse(mailstream * fd, MMAPString * buffe
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_time_parse(fd, buffer, &cur_token, &hour, &min, &sec);
+  r = mailimap_time_parse(fd, buffer, parser_ctx, &cur_token, &hour, &min, &sec);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_date_time_no_quote_space_timezone_parse(fd, buffer, &cur_token, &zone);
+  r = mailimap_date_time_no_quote_space_timezone_parse(fd, buffer, parser_ctx, &cur_token, &zone);
   if (r == MAILIMAP_ERROR_PARSE) {
     zone = get_current_timezone_offset();
   }
@@ -4506,7 +4506,7 @@ int mailimap_hack_date_time_parse(char * str,
   
   cur_token = 0;
   
-  r = mailimap_date_time_no_quote_parse(fd, buffer, &cur_token, &date_time,
+  r = mailimap_date_time_no_quote_parse(fd, buffer, NULL, &cur_token, &date_time,
                                         progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
@@ -4517,7 +4517,7 @@ int mailimap_hack_date_time_parse(char * str,
   return MAILIMAP_NO_ERROR;
 }
 
-static int mailimap_date_time_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_date_time_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                     size_t * indx,
                                     struct mailimap_date_time ** result,
                                     size_t progr_rate,
@@ -4530,20 +4530,20 @@ static int mailimap_date_time_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
   
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
   
-  r = mailimap_date_time_no_quote_parse(fd, buffer, &cur_token,
+  r = mailimap_date_time_no_quote_parse(fd, buffer, parser_ctx, &cur_token,
                                         &date_time, progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
   
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_date_time;
@@ -4577,7 +4577,7 @@ static int is_digit_nz(char ch)
   return (ch >= '1') && (ch <= '9');
 }
 
-static int mailimap_digit_nz_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_digit_nz_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, int * result)
 {
   size_t cur_token;
@@ -4601,14 +4601,14 @@ static int mailimap_digit_nz_parse(mailstream * fd, MMAPString * buffer,
                      env-in-reply-to SP env-message-id ")"
 */
 
-static int mailimap_envelope_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_envelope_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx,
 				   struct mailimap_envelope ** result,
 				   size_t progr_rate,
 				   progress_function * progr_fun)
 {
   int r;
-  r = mailimap_envelope_parse_full(fd, buffer, indx, result, progr_rate, progr_fun);
+  r = mailimap_envelope_parse_full(fd, buffer, parser_ctx, indx, result, progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     return MAILIMAP_NO_ERROR;
   }
@@ -4617,11 +4617,11 @@ static int mailimap_envelope_parse(mailstream * fd, MMAPString * buffer,
   }
 
   /* workaround for qq.com IMAP Server. */
-  r = mailimap_envelope_parse_workaround_qq_mail(fd, buffer, indx, result, progr_rate, progr_fun);
+  r = mailimap_envelope_parse_workaround_qq_mail(fd, buffer, parser_ctx, indx, result, progr_rate, progr_fun);
   return r;
 }
 
-static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
+static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                         size_t * indx,
                                         struct mailimap_envelope ** result,
                                         size_t progr_rate,
@@ -4655,13 +4655,13 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_env_date_parse(fd, buffer, &cur_token, &date,
+  r = mailimap_env_date_parse(fd, buffer, parser_ctx, &cur_token, &date,
 			      progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4674,7 +4674,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto date;
   }
 
-  r = mailimap_env_subject_parse(fd, buffer, &cur_token, &subject,
+  r = mailimap_env_subject_parse(fd, buffer, parser_ctx, &cur_token, &subject,
 				 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4687,7 +4687,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto subject;
   }
 
-  r = mailimap_env_from_parse(fd, buffer, &cur_token, &from,
+  r = mailimap_env_from_parse(fd, buffer, parser_ctx, &cur_token, &from,
 			      progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4700,7 +4700,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto from;
   }
 
-  r = mailimap_env_sender_parse(fd, buffer, &cur_token, &sender,
+  r = mailimap_env_sender_parse(fd, buffer, parser_ctx, &cur_token, &sender,
 				progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4713,7 +4713,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto sender;
   }
 
-  r = mailimap_env_reply_to_parse(fd, buffer, &cur_token, &reply_to,
+  r = mailimap_env_reply_to_parse(fd, buffer, parser_ctx, &cur_token, &reply_to,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4726,7 +4726,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto reply_to;
   }
 
-  r = mailimap_env_to_parse(fd, buffer, &cur_token, &to,
+  r = mailimap_env_to_parse(fd, buffer, parser_ctx, &cur_token, &to,
 			    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4739,7 +4739,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto to;
   }
 
-  r = mailimap_env_cc_parse(fd, buffer, &cur_token, &cc,
+  r = mailimap_env_cc_parse(fd, buffer, parser_ctx, &cur_token, &cc,
 			    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4752,7 +4752,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto cc;
   }
 
-  r = mailimap_env_bcc_parse(fd, buffer, &cur_token, &bcc,
+  r = mailimap_env_bcc_parse(fd, buffer, parser_ctx, &cur_token, &bcc,
 			     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4765,7 +4765,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto bcc;
   }
 
-  r = mailimap_env_in_reply_to_parse(fd, buffer, &cur_token, &in_reply_to,
+  r = mailimap_env_in_reply_to_parse(fd, buffer, parser_ctx, &cur_token, &in_reply_to,
 				     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4778,14 +4778,14 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
     goto in_reply_to;
   }
 
-  r = mailimap_env_message_id_parse(fd, buffer, &cur_token, &message_id,
+  r = mailimap_env_message_id_parse(fd, buffer, parser_ctx, &cur_token, &message_id,
 				    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto in_reply_to;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto message_id;
@@ -4827,7 +4827,7 @@ static int mailimap_envelope_parse_full(mailstream * fd, MMAPString * buffer,
   return res;
 }
 
-static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPString * buffer,
+static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                                       size_t * indx,
                                                       struct mailimap_envelope ** result,
                                                       size_t progr_rate,
@@ -4857,13 +4857,13 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_env_date_parse(fd, buffer, &cur_token, &date,
+  r = mailimap_env_date_parse(fd, buffer, parser_ctx, &cur_token, &date,
                               progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4876,7 +4876,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
     goto date;
   }
 
-  r = mailimap_env_subject_parse(fd, buffer, &cur_token, &subject,
+  r = mailimap_env_subject_parse(fd, buffer, parser_ctx, &cur_token, &subject,
                                  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -4889,7 +4889,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
     goto subject;
   }
 
-  r = mailimap_env_from_parse(fd, buffer, &cur_token, &from,
+  r = mailimap_env_from_parse(fd, buffer, parser_ctx, &cur_token, &from,
                               progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE)) {
     res = r;
@@ -4938,7 +4938,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
       goto from;
     }
 
-    r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+    r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
                                     progr_rate, progr_fun);
     if (r == MAILIMAP_ERROR_PARSE) {
       break;
@@ -4954,7 +4954,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
   }
 
   has_first_string = 0;
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &first_string, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &first_string, NULL,
                                 progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     has_first_string = 1;
@@ -4971,7 +4971,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
   // ignore errors.
 
   has_second_string = 0;
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &second_string, NULL,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &second_string, NULL,
                              progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR) {
     has_second_string = 1;
@@ -4992,7 +4992,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
     message_id = first_string;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto second_string;
@@ -5028,7 +5028,7 @@ err:
   "(" 1*address ")" / nil
 */
 
-static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx,
 				       clist ** result,
 				       size_t progr_rate,
@@ -5043,20 +5043,20 @@ static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer,
 
   address_list = NULL;
 
-  r = mailimap_nil_parse(fd, buffer, &cur_token);
+  r = mailimap_nil_parse(fd, buffer, parser_ctx, &cur_token);
   switch (r) {
   case MAILIMAP_NO_ERROR:
     address_list = NULL;
     break;
  
   case MAILIMAP_ERROR_PARSE:
-    r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto err;
     }
 				   
-    r = mailimap_struct_multiple_parse(fd, buffer, &cur_token, &address_list,
+    r = mailimap_struct_multiple_parse(fd, buffer, parser_ctx, &cur_token, &address_list,
 				       (mailimap_struct_parser *)
 				       mailimap_address_parse,
 				       (mailimap_struct_destructor *)
@@ -5070,7 +5070,7 @@ static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer,
       goto err;
     }
     
-    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto address_list;
@@ -5102,7 +5102,7 @@ static int mailimap_address_list_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_env_bcc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_bcc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx, struct mailimap_env_bcc ** result,
 		       size_t progr_rate,
 		       progress_function * progr_fun)
@@ -5116,7 +5116,7 @@ mailimap_env_bcc_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
 
-  r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -5146,7 +5146,7 @@ mailimap_env_bcc_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_env_cc_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_cc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		      size_t * indx, struct mailimap_env_cc ** result,
 		      size_t progr_rate,
 		      progress_function * progr_fun)
@@ -5160,7 +5160,7 @@ mailimap_env_cc_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
 
-  r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -5189,12 +5189,12 @@ mailimap_env_cc_parse(mailstream * fd, MMAPString * buffer,
    env-date        = nstring
 */
 
-static int mailimap_env_date_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_env_date_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, char ** result,
 				   size_t progr_rate,
 				   progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -5203,7 +5203,7 @@ static int mailimap_env_date_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_env_from_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_from_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			size_t * indx, struct mailimap_env_from ** result,
 			size_t progr_rate,
 			progress_function * progr_fun)
@@ -5217,7 +5217,7 @@ mailimap_env_from_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
   
-  r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -5247,12 +5247,12 @@ mailimap_env_from_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int mailimap_env_in_reply_to_parse(mailstream * fd,
-					  MMAPString * buffer,
+					  MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					  size_t * indx, char ** result,
 					  size_t progr_rate,
 					  progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -5261,12 +5261,12 @@ static int mailimap_env_in_reply_to_parse(mailstream * fd,
 */
 
 static int mailimap_env_message_id_parse(mailstream * fd,
-					 MMAPString * buffer,
+					 MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					 size_t * indx, char ** result,
 					 size_t progr_rate,
 					 progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -5275,7 +5275,7 @@ static int mailimap_env_message_id_parse(mailstream * fd,
 */
 
 static int
-mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_env_reply_to ** result,
 			    size_t progr_rate,
@@ -5290,7 +5290,7 @@ mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
   
-  r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -5321,7 +5321,7 @@ mailimap_env_reply_to_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_env_sender_parse(mailstream * fd, MMAPString * buffer,
+mailimap_env_sender_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			  size_t * indx, struct mailimap_env_sender ** result,
 			  size_t progr_rate,
 			  progress_function * progr_fun)
@@ -5335,7 +5335,7 @@ mailimap_env_sender_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
   
-  r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -5365,12 +5365,12 @@ mailimap_env_sender_parse(mailstream * fd, MMAPString * buffer,
    env-subject     = nstring
 */
 
-static int mailimap_env_subject_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_env_subject_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				      size_t * indx, char ** result,
 				      size_t progr_rate,
 				      progress_function * progr_fun)
 {
-  return mailimap_nstring_parse(fd, buffer, indx, result, NULL,
+  return mailimap_nstring_parse(fd, buffer, parser_ctx, indx, result, NULL,
 				progr_rate, progr_fun);
 }
 
@@ -5379,7 +5379,7 @@ static int mailimap_env_subject_parse(mailstream * fd, MMAPString * buffer,
    env-to          = "(" 1*address ")" / nil
 */
 
-static int mailimap_env_to_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_env_to_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx,
 				 struct mailimap_env_to ** result,
 				 size_t progr_rate,
@@ -5394,7 +5394,7 @@ static int mailimap_env_to_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
   
-  r = mailimap_address_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_address_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -5445,7 +5445,7 @@ static int mailimap_env_to_parse(mailstream * fd, MMAPString * buffer,
                        ; Does not include "\Recent"
 */
 
-static int mailimap_flag_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_flag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_flag ** result,
 			       size_t progr_rate,
@@ -5466,13 +5466,13 @@ static int mailimap_flag_parse(mailstream * fd, MMAPString * buffer,
 
   type = mailimap_flag_get_token_value(fd, buffer, &cur_token);
   if (type == -1) {
-    r = mailimap_flag_keyword_parse(fd, buffer, &cur_token, &flag_keyword,
+    r = mailimap_flag_keyword_parse(fd, buffer, parser_ctx, &cur_token, &flag_keyword,
 				    progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_FLAG_KEYWORD;
 
     if (r == MAILIMAP_ERROR_PARSE) {
-      r = mailimap_flag_extension_parse(fd, buffer, &cur_token, 
+      r = mailimap_flag_extension_parse(fd, buffer, parser_ctx, &cur_token, 
 					&flag_extension,
 					progr_rate, progr_fun);
       type = MAILIMAP_FLAG_EXTENSION;
@@ -5515,7 +5515,7 @@ static int mailimap_flag_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int mailimap_flag_extension_parse(mailstream * fd,
-					 MMAPString * buffer,
+					 MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					 size_t * indx,
 					 char ** result,
 					 size_t progr_rate,
@@ -5535,7 +5535,7 @@ static int mailimap_flag_extension_parse(mailstream * fd,
     return r;
 
   atom = NULL;
-  r = mailimap_atom_parse(fd, buffer, &cur_token, &atom,
+  r = mailimap_atom_parse(fd, buffer, parser_ctx, &cur_token, &atom,
 			  progr_rate, progr_fun);
   if (r == MAILIMAP_ERROR_PARSE) {
     /* workaround for binc IMAP */
@@ -5565,7 +5565,7 @@ static int mailimap_flag_extension_parse(mailstream * fd,
 */
 
 static int
-mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer,
+mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			  size_t * indx,
 			  struct mailimap_flag_fetch ** result,
 			  size_t progr_rate,
@@ -5590,7 +5590,7 @@ mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer,
     type = MAILIMAP_FLAG_FETCH_RECENT;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_flag_parse(fd, buffer, &cur_token, &flag,
+    r = mailimap_flag_parse(fd, buffer, parser_ctx, &cur_token, &flag,
 			    progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_FLAG_FETCH_OTHER;
@@ -5625,17 +5625,17 @@ mailimap_flag_fetch_parse(mailstream * fd, MMAPString * buffer,
    http://www.rockliffe.com/
 */
 
-static int mailimap_flag_keyword_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_flag_keyword_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				       size_t * indx,
 				       char ** result,
 				       size_t progr_rate,
 				       progress_function * progr_fun)
 {
 #if 0
-  return mailimap_atom_parse(fd, buffer, indx, result,
+  return mailimap_atom_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
 #endif
-  return mailimap_astring_parse(fd, buffer, indx, result,
+  return mailimap_astring_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
 }
 
@@ -5643,7 +5643,7 @@ static int mailimap_flag_keyword_parse(mailstream * fd, MMAPString * buffer,
    flag-list       = "(" [flag *(SP flag)] ")"
 */
 
-static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx,
 				    struct mailimap_flag_list ** result,
 				    size_t progr_rate,
@@ -5658,13 +5658,13 @@ static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer,
   list = NULL;
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 					(mailimap_struct_parser *)
 					mailimap_flag_parse,
 					(mailimap_struct_destructor *)
@@ -5676,7 +5676,7 @@ static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -5707,7 +5707,7 @@ static int mailimap_flag_list_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer,
+mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 size_t * indx,
 			 struct mailimap_flag_perm ** result,
 			 size_t progr_rate,
@@ -5730,7 +5730,7 @@ mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer,
     type = MAILIMAP_FLAG_PERM_ALL;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_flag_parse(fd, buffer, &cur_token, &flag,
+    r = mailimap_flag_parse(fd, buffer, parser_ctx, &cur_token, &flag,
                             progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_FLAG_PERM_FLAG;
@@ -5764,7 +5764,7 @@ mailimap_flag_perm_parse(mailstream * fd, MMAPString * buffer,
    greeting        = "*" SP (resp-cond-auth / resp-cond-bye) CRLF
 */
 
-int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_greeting ** result,
 			    size_t progr_rate,
@@ -5782,7 +5782,7 @@ int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer,
   resp_cond_bye = NULL;
   resp_cond_auth = NULL;
 
-  r = mailimap_star_parse(fd, buffer, &cur_token);
+  r = mailimap_star_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -5796,13 +5796,13 @@ int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_GREETING_RESP_COND_ERROR; /* XXX - removes a gcc warning */
   
-  r = mailimap_resp_cond_auth_parse(fd, buffer, &cur_token, &resp_cond_auth,
+  r = mailimap_resp_cond_auth_parse(fd, buffer, parser_ctx, &cur_token, &resp_cond_auth,
 				    progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_GREETING_RESP_COND_AUTH;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_resp_cond_bye_parse(fd, buffer, &cur_token,
+    r = mailimap_resp_cond_bye_parse(fd, buffer, parser_ctx, &cur_token,
 				     &resp_cond_bye,
 				     progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -5814,7 +5814,7 @@ int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_crlf_parse(fd, buffer, &cur_token);
+  r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -5846,13 +5846,13 @@ int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_header_fld_name_parse(mailstream * fd,
-			       MMAPString * buffer,
+			       MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       char ** result,
 			       size_t progr_rate,
 			       progress_function * progr_fun)
 {
-  return mailimap_astring_parse(fd, buffer, indx, result,
+  return mailimap_astring_parse(fd, buffer, parser_ctx, indx, result,
 				progr_rate, progr_fun);
 }
 
@@ -5861,7 +5861,7 @@ mailimap_header_fld_name_parse(mailstream * fd,
 */
 
 static int
-mailimap_header_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_header_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_header_list ** result,
 			   size_t progr_rate,
@@ -5877,13 +5877,13 @@ mailimap_header_list_parse(mailstream * fd, MMAPString * buffer,
 
   list = NULL;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &list,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &list,
 					(mailimap_struct_parser *)
 					mailimap_header_fld_name_parse,
 					(mailimap_struct_destructor *)
@@ -5894,7 +5894,7 @@ mailimap_header_list_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -5951,7 +5951,7 @@ static int is_list_wildcards(char ch)
 
 #define MAX_READ_PROGRESS 65536
 
-static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
+static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                            size_t * indx, char ** result,
                                            size_t * result_len,
                                            size_t progr_rate,
@@ -5973,7 +5973,7 @@ static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
   
-  r = mailimap_oaccolade_parse(fd, buffer, &cur_token);
+  r = mailimap_oaccolade_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -5984,7 +5984,7 @@ static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
   r = mailimap_number_parse(fd, buffer, &cur_token, &number);
   if (r == MAILIMAP_ERROR_PARSE) {
     // workaround issue with Free servers
-    r = mailimap_minus_parse(fd, buffer, &cur_token);
+    r = mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto err;
@@ -6001,13 +6001,13 @@ static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
     goto err;
   }
   
-  r = mailimap_caccolade_parse(fd, buffer, &cur_token);
+  r = mailimap_caccolade_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
   
-  r = mailimap_crlf_parse(fd, buffer, &cur_token);
+  r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
 	if (r == MAILIMAP_ERROR_PARSE) {
 		/* workaround for Lotus Domino IMAP server */
 		mailimap_space_parse(fd, buffer, &cur_token);
@@ -6074,7 +6074,32 @@ static int mailimap_literal_parse_progress(mailstream * fd, MMAPString * buffer,
       literal->len += read_bytes;
       needed -= read_bytes;
       literal_p += read_bytes;
-      
+
+      if (needed > 0 && mailimap_parser_context_is_rambler_workaround_enabled(parser_ctx)) {
+        /* workaround issue with Rambler IMAP server */
+        char const *literal_end = literal_p;
+        char tag_response_end[] = " OK completed\r\n";
+        size_t tag_response_end_len = sizeof(tag_response_end) - 1;
+        /* Looking backward for pattern " UID \d+)\r\n\d+ OK completed\r\n$" */
+        if (literal->len >= tag_response_end_len && memcmp(literal_end - tag_response_end_len, tag_response_end, tag_response_end_len) == 0) {
+          literal_end -= tag_response_end_len;
+          /* match tag */
+          while (literal_end > literal->str && is_digit(*(literal_end - 1))) literal_end--;
+          /* match closing parenthesis and CRLF */
+          if (literal_end > literal->str + 3) literal_end -= 3;
+          if (memcmp(literal_end, ")\r\n", 3) == 0) {
+            /* match uid */
+            while (literal_end > literal->str && is_digit(*(literal_end - 1))) literal_end--;
+            if (literal_end > literal->str + 5) literal_end -= 5;
+            if (memcmp(literal_end, " UID ", 5) == 0) {
+              /* got invalid server response, no more data will received */
+              res = MAILIMAP_ERROR_PARSE;
+              goto free_literal;
+            }
+          }
+        }
+      }
+
       current_prog += read_bytes;
       if (current_prog - last_prog > progr_rate) {
         if (progr_fun != NULL) {
@@ -6161,7 +6186,7 @@ err:
 */
 
 int
-mailimap_mailbox_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx, char ** result,
 		       size_t progr_rate,
 		       progress_function * progr_fun)
@@ -6172,7 +6197,7 @@ mailimap_mailbox_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_astring_parse(fd, buffer, &cur_token, &name,
+  r = mailimap_astring_parse(fd, buffer, parser_ctx, &cur_token, &name,
 			     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -6184,7 +6209,7 @@ mailimap_mailbox_parse(mailstream * fd, MMAPString * buffer,
 }
 
 static int
-mailimap_mailbox_gmail_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_gmail_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, char ** result,
     size_t progr_rate,
     progress_function * progr_fun)
@@ -6198,7 +6223,7 @@ mailimap_mailbox_gmail_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &astring_list,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &astring_list,
 					(mailimap_struct_parser *)
 					mailimap_astring_parse,
 					(mailimap_struct_destructor *)
@@ -6243,7 +6268,7 @@ mailimap_mailbox_gmail_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_flags_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_flags_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx,
 				  struct mailimap_flag_list ** result,
 				  size_t progr_rate,
@@ -6264,7 +6289,7 @@ mailimap_mailbox_data_flags_parse(mailstream * fd, MMAPString * buffer,
     return r;
 
   flag_list = NULL;
-  r = mailimap_flag_list_parse(fd, buffer, &cur_token, &flag_list,
+  r = mailimap_flag_list_parse(fd, buffer, parser_ctx, &cur_token, &flag_list,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -6281,7 +6306,7 @@ mailimap_mailbox_data_flags_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx,
 				 struct mailimap_mailbox_list ** result,
 				 size_t progr_rate,
@@ -6303,7 +6328,7 @@ mailimap_mailbox_data_list_parse(mailstream * fd, MMAPString * buffer,
     return r;
   }
 
-  r = mailimap_mailbox_list_parse(fd, buffer, &cur_token, &mb_list,
+  r = mailimap_mailbox_list_parse(fd, buffer, parser_ctx, &cur_token, &mb_list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
@@ -6320,7 +6345,7 @@ mailimap_mailbox_data_list_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_lsub_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_lsub_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx,
 				 struct mailimap_mailbox_list ** result,
 				 size_t progr_rate,
@@ -6340,7 +6365,7 @@ mailimap_mailbox_data_lsub_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_mailbox_list_parse(fd, buffer, &cur_token, &mb_list,
+  r = mailimap_mailbox_list_parse(fd, buffer, parser_ctx, &cur_token, &mb_list,
 				  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -6357,7 +6382,7 @@ mailimap_mailbox_data_lsub_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_mailbox_data_search_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_search_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx,
 				   clist ** result,
 				   size_t progr_rate,
@@ -6380,7 +6405,7 @@ mailimap_mailbox_data_search_parse(mailstream * fd, MMAPString * buffer,
 
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
-    r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &number_list,
+    r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &number_list,
 					  (mailimap_struct_parser *)
 					  mailimap_nz_number_alloc_parse,
 					  (mailimap_struct_destructor *)
@@ -6406,7 +6431,7 @@ mailimap_mailbox_data_search_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_status_info_parse(mailstream * fd, MMAPString * buffer,
+mailimap_status_info_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_status_info **
 			   result,
@@ -6422,7 +6447,7 @@ mailimap_status_info_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   value = 0;
 
-  r = mailimap_status_att_parse(fd, buffer, &cur_token, &status_att);
+  r = mailimap_status_att_parse(fd, buffer, parser_ctx, &cur_token, &status_att);
   if (r == MAILIMAP_NO_ERROR) {
     /* Force parse error when HIGHESTMODSEQ is parsed */
     if (status_att == MAILIMAP_STATUS_ATT_HIGHESTMODSEQ) {
@@ -6434,7 +6459,7 @@ mailimap_status_info_parse(mailstream * fd, MMAPString * buffer,
     
     cur_token = * indx;
     r = mailimap_extension_data_parse(MAILIMAP_EXTENDED_PARSER_STATUS_ATT,
-        fd, buffer, &cur_token, &ext_data,
+        fd, buffer, parser_ctx, &cur_token, &ext_data,
         progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR) {
       info = mailimap_status_info_new(MAILIMAP_STATUS_ATT_EXTENSION, 0, ext_data);
@@ -6475,7 +6500,7 @@ mailimap_status_info_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_status_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_status_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, struct
 				   mailimap_mailbox_data_status ** result,
 				   size_t progr_rate,
@@ -6504,7 +6529,7 @@ mailimap_mailbox_data_status_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_gmail_parse(fd, buffer, &cur_token, &mb,
+  r = mailimap_mailbox_gmail_parse(fd, buffer, parser_ctx, &cur_token, &mb,
       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -6517,13 +6542,13 @@ mailimap_mailbox_data_status_parse(mailstream * fd, MMAPString * buffer,
     goto mailbox;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto mailbox;
   }
   
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token,
 					&status_info_list,
 					(mailimap_struct_parser *)
 					mailimap_status_info_parse,
@@ -6535,7 +6560,7 @@ mailimap_mailbox_data_status_parse(mailstream * fd, MMAPString * buffer,
     goto mailbox;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto status_info_list;
@@ -6569,7 +6594,7 @@ mailimap_mailbox_data_status_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_exists_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_exists_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx,
 				   uint32_t * result)
 {
@@ -6602,7 +6627,7 @@ mailimap_mailbox_data_exists_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_recent_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_recent_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx,
 				   uint32_t * result)
 {
@@ -6640,7 +6665,7 @@ mailimap_mailbox_data_recent_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_mailbox_data ** result,
 			    size_t progr_rate,
@@ -6674,14 +6699,14 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_MAILBOX_DATA_ERROR; /* XXX - removes a gcc warning */
   
-  r = mailimap_mailbox_data_flags_parse(fd, buffer, &cur_token,
+  r = mailimap_mailbox_data_flags_parse(fd, buffer, parser_ctx, &cur_token,
 					&data_flags,
 					progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_MAILBOX_DATA_FLAGS;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_list_parse(fd, buffer, &cur_token,
+    r = mailimap_mailbox_data_list_parse(fd, buffer, parser_ctx, &cur_token,
 					 &data_list,
 					 progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -6689,7 +6714,7 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_lsub_parse(fd, buffer, &cur_token,
+    r = mailimap_mailbox_data_lsub_parse(fd, buffer, parser_ctx, &cur_token,
 					 &data_lsub,
 					 progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -6697,7 +6722,7 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_search_parse(fd, buffer, &cur_token,
+    r = mailimap_mailbox_data_search_parse(fd, buffer, parser_ctx, &cur_token,
 					   &data_search,
 					   progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -6705,7 +6730,7 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_status_parse(fd, buffer, &cur_token,
+    r = mailimap_mailbox_data_status_parse(fd, buffer, parser_ctx, &cur_token,
 					   &data_status,
 					   progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -6713,14 +6738,14 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
   }
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_exists_parse(fd, buffer, &cur_token,
+    r = mailimap_mailbox_data_exists_parse(fd, buffer, parser_ctx, &cur_token,
 					   &data_exists);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MAILBOX_DATA_EXISTS;
   }
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_recent_parse(fd, buffer, &cur_token,
+    r = mailimap_mailbox_data_recent_parse(fd, buffer, parser_ctx, &cur_token,
 					   &data_recent);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MAILBOX_DATA_RECENT;
@@ -6728,7 +6753,7 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
 
   if (r == MAILIMAP_ERROR_PARSE) {
     r = mailimap_extension_data_parse(MAILIMAP_EXTENDED_PARSER_MAILBOX_DATA,
-              fd, buffer, &cur_token, &data_extension, progr_rate,
+              fd, buffer, parser_ctx, &cur_token, &data_extension, progr_rate,
               progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MAILBOX_DATA_EXTENSION_DATA;
@@ -6782,7 +6807,7 @@ mailimap_mailbox_data_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mailbox_list_quoted_char_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_list_quoted_char_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					size_t * indx,
 					char * result)
 {
@@ -6792,15 +6817,15 @@ mailimap_mailbox_list_quoted_char_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_quoted_char_parse(fd, buffer, &cur_token, &ch);
+  r = mailimap_quoted_char_parse(fd, buffer, parser_ctx, &cur_token, &ch);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -6811,7 +6836,7 @@ mailimap_mailbox_list_quoted_char_parse(mailstream * fd, MMAPString * buffer,
 }
 
 int
-mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_mailbox_list ** result,
 			    size_t progr_rate,
@@ -6827,7 +6852,7 @@ mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -6837,14 +6862,14 @@ mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
   ch = 0;
   mb = NULL;
 
-  r = mailimap_mbx_list_flags_parse(fd, buffer, &cur_token,
+  r = mailimap_mbx_list_flags_parse(fd, buffer, parser_ctx, &cur_token,
 				    &mb_flag_list, progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE)) {
     res = r;
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free_list_flags;
@@ -6856,9 +6881,9 @@ mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
     goto free_list_flags;
   }
 
-  r = mailimap_mailbox_list_quoted_char_parse(fd, buffer, &cur_token, &ch);
+  r = mailimap_mailbox_list_quoted_char_parse(fd, buffer, parser_ctx, &cur_token, &ch);
   if (r == MAILIMAP_ERROR_PARSE)
-    r = mailimap_nil_parse(fd, buffer, &cur_token);
+    r = mailimap_nil_parse(fd, buffer, parser_ctx, &cur_token);
 
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -6871,7 +6896,7 @@ mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
     goto free_list_flags;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, &cur_token, &mb,
+  r = mailimap_mailbox_parse(fd, buffer, parser_ctx, &cur_token, &mb,
 			     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -6905,7 +6930,7 @@ mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_mbx_list_flags ** result,
 			      size_t progr_rate,
@@ -6934,7 +6959,7 @@ mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer,
   sflag = MAILIMAP_MBX_LIST_SFLAG_ERROR;
   oflags_2 = NULL;
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token,
 					&oflags_2,
 					(mailimap_struct_parser *)
 					mailimap_mbx_list_oflag_no_sflag_parse,
@@ -6960,7 +6985,7 @@ mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer,
   
   type = MAILIMAP_MBX_LIST_FLAGS_NO_SFLAG;
   if (try_sflag) {
-    r = mailimap_mbx_list_sflag_parse(fd, buffer, &cur_token, &sflag);
+    r = mailimap_mbx_list_sflag_parse(fd, buffer, parser_ctx, &cur_token, &sflag);
     switch (r) {
     case MAILIMAP_ERROR_PARSE:
       type = MAILIMAP_MBX_LIST_FLAGS_NO_SFLAG;
@@ -6972,7 +6997,7 @@ mailimap_mbx_list_flags_parse(mailstream * fd, MMAPString * buffer,
       final_token = cur_token;
       r = mailimap_space_parse(fd, buffer, &cur_token);
       if (r == MAILIMAP_NO_ERROR) {
-        r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token,
+        r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token,
             &oflags_2,
             (mailimap_struct_parser *) mailimap_mbx_list_oflag_parse,
             (mailimap_struct_destructor *) mailimap_mbx_list_oflag_free,
@@ -7028,7 +7053,7 @@ err:
 */
 
 static int
-mailimap_mbx_list_oflag_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_oflag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_mbx_list_oflag ** result,
 			      size_t progr_rate,
@@ -7058,7 +7083,7 @@ mailimap_mbx_list_oflag_parse(mailstream * fd, MMAPString * buffer,
   }
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_flag_extension_parse(fd, buffer, &cur_token,
+    r = mailimap_flag_extension_parse(fd, buffer, parser_ctx, &cur_token,
 				      &flag_ext, progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MBX_LIST_OFLAG_FLAG_EXT;
@@ -7088,7 +7113,7 @@ mailimap_mbx_list_oflag_parse(mailstream * fd, MMAPString * buffer,
 }
 
 static int
-mailimap_mbx_list_oflag_no_sflag_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_oflag_no_sflag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx,
     struct mailimap_mbx_list_oflag ** result,
     size_t progr_rate,
@@ -7100,11 +7125,11 @@ mailimap_mbx_list_oflag_no_sflag_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
   
-  r = mailimap_mbx_list_sflag_parse(fd, buffer, &cur_token, &sflag_type);
+  r = mailimap_mbx_list_sflag_parse(fd, buffer, parser_ctx, &cur_token, &sflag_type);
   if (r == MAILIMAP_NO_ERROR)
     return MAILIMAP_ERROR_PARSE;
   
-  return mailimap_mbx_list_oflag_parse(fd, buffer, indx, result,
+  return mailimap_mbx_list_oflag_parse(fd, buffer, parser_ctx, indx, result,
       progr_rate, progr_fun);
 }
 
@@ -7115,7 +7140,7 @@ mailimap_mbx_list_oflag_no_sflag_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_mbx_list_sflag_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mbx_list_sflag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      int * result)
 {
@@ -7147,7 +7172,7 @@ mailimap_mbx_list_sflag_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_media_basic_standard_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_basic_standard_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx,
 				    int * result)
 {
@@ -7157,7 +7182,7 @@ mailimap_media_basic_standard_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7165,7 +7190,7 @@ mailimap_media_basic_standard_parse(mailstream * fd, MMAPString * buffer,
   if (type == -1)
     return MAILIMAP_ERROR_PARSE;
     
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7182,7 +7207,7 @@ mailimap_media_basic_standard_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   struct mailimap_media_basic ** result,
 			   size_t progr_rate,
@@ -7202,11 +7227,11 @@ mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
   subtype = NULL;
 
   type = MAILIMAP_MEDIA_BASIC_OTHER;
-  r = mailimap_media_basic_standard_parse(fd, buffer, &cur_token,
+  r = mailimap_media_basic_standard_parse(fd, buffer, parser_ctx, &cur_token,
 					  &type);
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_string_parse(fd, buffer, &cur_token, &basic_type, NULL,
+    r = mailimap_string_parse(fd, buffer, parser_ctx, &cur_token, &basic_type, NULL,
 			      progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MEDIA_BASIC_OTHER;
@@ -7214,7 +7239,7 @@ mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
   
   // workaround for mbox mail for mac
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_nil_parse(fd, buffer, &cur_token);
+    r = mailimap_nil_parse(fd, buffer, parser_ctx, &cur_token);
     if (r == MAILIMAP_NO_ERROR) {
       type = MAILIMAP_MEDIA_BASIC_APPLICATION;
     }
@@ -7231,7 +7256,7 @@ mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
     goto free_basic_type;
   }
 
-  r = mailimap_media_subtype_parse(fd, buffer, &cur_token, &subtype,
+  r = mailimap_media_subtype_parse(fd, buffer, parser_ctx, &cur_token, &subtype,
 				   progr_rate, progr_fun);
   if (r == MAILIMAP_ERROR_PARSE) {
     // workaround for mbox mail for mac
@@ -7243,7 +7268,7 @@ mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
   
   if (r == MAILIMAP_ERROR_PARSE) {
     // workaround for mbox mail for mac
-    r = mailimap_nil_parse(fd, buffer, &cur_token);
+    r = mailimap_nil_parse(fd, buffer, parser_ctx, &cur_token);
     if (r == MAILIMAP_NO_ERROR) {
       subtype = strdup("DATA"); // application data
       if (subtype == NULL) {
@@ -7280,7 +7305,7 @@ mailimap_media_basic_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_message_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx)
 {
   size_t cur_token;
@@ -7288,7 +7313,7 @@ mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7297,7 +7322,7 @@ mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7305,7 +7330,7 @@ mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7323,7 +7348,7 @@ mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7338,13 +7363,13 @@ mailimap_media_message_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_media_subtype_parse(mailstream * fd, MMAPString * buffer,
+mailimap_media_subtype_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     char ** result,
 			     size_t progr_rate,
 			     progress_function * progr_fun)
 {
-  return mailimap_string_parse(fd, buffer, indx, result, NULL,
+  return mailimap_string_parse(fd, buffer, parser_ctx, indx, result, NULL,
 			       progr_rate, progr_fun);
 }
 
@@ -7353,7 +7378,7 @@ mailimap_media_subtype_parse(mailstream * fd, MMAPString * buffer,
                        ; Defined in [MIME-IMT]
 */
 
-static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx,
 				     char ** result,
 				     size_t progr_rate,
@@ -7365,7 +7390,7 @@ static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7374,7 +7399,7 @@ static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -7382,7 +7407,7 @@ static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_media_subtype_parse(fd, buffer, &cur_token, &media_subtype,
+  r = mailimap_media_subtype_parse(fd, buffer, parser_ctx, &cur_token, &media_subtype,
 				   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -7400,7 +7425,7 @@ static int mailimap_media_text_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_message_data_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_message_data_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                      size_t * indx,
                                      struct mailimap_message_data ** result,
                                      size_t progr_rate,
@@ -7422,11 +7447,11 @@ mailimap_message_data_parse_progress(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   msg_att = NULL;
 
-	r = mailimap_nz_number_parse(fd, buffer, &cur_token, &number);
+	r = mailimap_nz_number_parse(fd, buffer, parser_ctx, &cur_token, &number);
 	if (r == MAILIMAP_ERROR_PARSE) {
 		// workaround for Zoho Mail IMAP server. sometimes returns negative message numbers
 
-	  r = mailimap_minus_parse(fd, buffer, &cur_token);
+	  r = mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token);
 		if (r != MAILIMAP_NO_ERROR) {
 			res = r;
 			goto err;
@@ -7471,7 +7496,7 @@ mailimap_message_data_parse_progress(mailstream * fd, MMAPString * buffer,
       goto err;
     }
 
-    r = mailimap_msg_att_parse_progress(fd, buffer, &cur_token, &msg_att,
+    r = mailimap_msg_att_parse_progress(fd, buffer, parser_ctx, &cur_token, &msg_att,
 			       progr_rate, progr_fun, body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -7518,7 +7543,7 @@ mailimap_message_data_parse_progress(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_item_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_item_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                      size_t * indx,
                                      struct mailimap_msg_att_item ** result,
                                      size_t progr_rate,
@@ -7546,14 +7571,14 @@ mailimap_msg_att_item_parse_progress(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_MSG_ATT_ITEM_ERROR; /* XXX - removes a gcc warning */
 
-  r = mailimap_msg_att_dynamic_parse(fd, buffer, &cur_token,
+  r = mailimap_msg_att_dynamic_parse(fd, buffer, parser_ctx, &cur_token,
 				     &msg_att_dynamic,
 				     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_MSG_ATT_ITEM_DYNAMIC;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_static_parse_progress(fd, buffer, &cur_token,
+    r = mailimap_msg_att_static_parse_progress(fd, buffer, parser_ctx, &cur_token,
                                                &msg_att_static,
                                                progr_rate, progr_fun,
                                                body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
@@ -7563,7 +7588,7 @@ mailimap_msg_att_item_parse_progress(mailstream * fd, MMAPString * buffer,
 
   if (r == MAILIMAP_ERROR_PARSE) {
     r = mailimap_extension_data_parse(MAILIMAP_EXTENDED_PARSER_FETCH_DATA,
-                                      fd, buffer, &cur_token, &msg_att_extension, progr_rate, progr_fun);
+                                      fd, buffer, parser_ctx, &cur_token, &msg_att_extension, progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MSG_ATT_ITEM_EXTENSION;
   }
@@ -7601,7 +7626,7 @@ mailimap_msg_att_item_parse_progress(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                 size_t * indx, struct mailimap_msg_att ** result,
                                 size_t progr_rate,
                                 progress_function * progr_fun,
@@ -7620,13 +7645,13 @@ mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   list = NULL;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse_progress(fd, buffer, &cur_token, &list,
+  r = mailimap_struct_spaced_list_parse_progress(fd, buffer, parser_ctx, &cur_token, &list,
                                                  (mailimap_struct_parser_progress *)
                                                  mailimap_msg_att_item_parse_progress,
                                                  (mailimap_struct_destructor *)
@@ -7639,7 +7664,7 @@ mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -7670,7 +7695,7 @@ mailimap_msg_att_parse_progress(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_msg_att_dynamic ** result,
 			       size_t progr_rate,
@@ -7698,13 +7723,13 @@ mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token,
 					&list,
 					(mailimap_struct_parser *)
 					mailimap_flag_fetch_parse,
@@ -7716,7 +7741,7 @@ mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -7758,7 +7783,7 @@ mailimap_msg_att_dynamic_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_msg_att_envelope_parse(mailstream * fd,
-				MMAPString * buffer,
+				MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx,
 				struct mailimap_envelope ** result,
 				size_t progr_rate,
@@ -7779,7 +7804,7 @@ mailimap_msg_att_envelope_parse(mailstream * fd,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_envelope_parse(fd, buffer, &cur_token, &env,
+  r = mailimap_envelope_parse(fd, buffer, parser_ctx, &cur_token, &env,
 			      progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -7797,7 +7822,7 @@ mailimap_msg_att_envelope_parse(mailstream * fd,
 
 
 static int
-mailimap_msg_att_internaldate_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_internaldate_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx,
 				    struct mailimap_date_time ** result,
 				    size_t progr_rate,
@@ -7818,7 +7843,7 @@ mailimap_msg_att_internaldate_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_date_time_parse(fd, buffer, &cur_token, &date_time,
+  r = mailimap_date_time_parse(fd, buffer, parser_ctx, &cur_token, &date_time,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -7834,7 +7859,7 @@ mailimap_msg_att_internaldate_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_rfc822_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_rfc822_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                        size_t * indx, char ** result,
                                        size_t * result_len,
                                        size_t progr_rate,
@@ -7861,7 +7886,7 @@ mailimap_msg_att_rfc822_parse_progress(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_nstring_parse_progress(fd, buffer, &cur_token, &rfc822_message, &length,
+  r = mailimap_nstring_parse_progress(fd, buffer, parser_ctx, &cur_token, &rfc822_message, &length,
          progr_rate, progr_fun, body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -7879,7 +7904,7 @@ mailimap_msg_att_rfc822_parse_progress(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_rfc822_header_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_rfc822_header_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx, char ** result,
 				     size_t * result_len,
 				     size_t progr_rate,
@@ -7906,7 +7931,7 @@ mailimap_msg_att_rfc822_header_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_nstring_parse(fd, buffer, &cur_token, &rfc822_header, &length,
+  r = mailimap_nstring_parse(fd, buffer, parser_ctx, &cur_token, &rfc822_header, &length,
 			     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -7924,7 +7949,7 @@ mailimap_msg_att_rfc822_header_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_rfc822_text_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_rfc822_text_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                             size_t * indx, char ** result,
                                             size_t * result_len,
                                             size_t progr_rate,
@@ -7956,7 +7981,7 @@ mailimap_msg_att_rfc822_text_parse_progress(mailstream * fd, MMAPString * buffer
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_nstring_parse_progress(fd, buffer, &cur_token, &rfc822_text, &length,
+  r = mailimap_nstring_parse_progress(fd, buffer, parser_ctx, &cur_token, &rfc822_text, &length,
                                       progr_rate, progr_fun, body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -7974,7 +7999,7 @@ mailimap_msg_att_rfc822_text_parse_progress(mailstream * fd, MMAPString * buffer
 */
 
 static int
-mailimap_msg_att_rfc822_size_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_rfc822_size_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, uint32_t * result)
 {
   size_t cur_token;
@@ -8008,7 +8033,7 @@ mailimap_msg_att_rfc822_size_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_msg_att_body_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_body_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx, struct mailimap_body ** result,
 			    size_t progr_rate,
 			    progress_function * progr_fun)
@@ -8028,7 +8053,7 @@ mailimap_msg_att_body_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_body_parse(fd, buffer, &cur_token, &body,
+  r = mailimap_body_parse(fd, buffer, parser_ctx, &cur_token, &body,
 			  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -8045,7 +8070,7 @@ mailimap_msg_att_body_parse(mailstream * fd, MMAPString * buffer,
 
 
 static int
-mailimap_msg_att_bodystructure_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_bodystructure_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx,
 				     struct mailimap_body ** result,
 				     size_t progr_rate,
@@ -8071,7 +8096,7 @@ mailimap_msg_att_bodystructure_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_body_parse(fd, buffer, &cur_token, &body,
+  r = mailimap_body_parse(fd, buffer, parser_ctx, &cur_token, &body,
 			  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -8087,7 +8112,7 @@ mailimap_msg_att_bodystructure_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                              size_t * indx,
                                              struct mailimap_msg_att_body_section **
                                              result,
@@ -8121,14 +8146,14 @@ mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffe
     goto err;
   }
 
-  r = mailimap_section_parse(fd, buffer, &cur_token, &section,
+  r = mailimap_section_parse(fd, buffer, parser_ctx, &cur_token, &section,
 			     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_lower_parse(fd, buffer, &cur_token);
+  r = mailimap_lower_parse(fd, buffer, parser_ctx, &cur_token);
   switch (r) {
   case MAILIMAP_NO_ERROR:
     r = mailimap_number_parse(fd, buffer, &cur_token, &number);
@@ -8137,7 +8162,7 @@ mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffe
       goto free_section;
     }
     
-    r = mailimap_greater_parse(fd, buffer, &cur_token);
+    r = mailimap_greater_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto free_section;
@@ -8157,7 +8182,7 @@ mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffe
     goto free_section;
   }
 
-  r = mailimap_nstring_parse_progress(fd, buffer, &cur_token, &body_part, &length,
+  r = mailimap_nstring_parse_progress(fd, buffer, parser_ctx, &cur_token, &body_part, &length,
                                       progr_rate, progr_fun, body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -8190,7 +8215,7 @@ mailimap_msg_att_body_section_parse_progress(mailstream * fd, MMAPString * buffe
 */
 
 static int
-mailimap_msg_att_uid_parse(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_uid_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx,
 			   uint32_t * result)
 {
@@ -8208,7 +8233,7 @@ mailimap_msg_att_uid_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_uniqueid_parse(fd, buffer, &cur_token, &uid);
+  r = mailimap_uniqueid_parse(fd, buffer, parser_ctx, &cur_token, &uid);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
@@ -8228,7 +8253,7 @@ mailimap_msg_att_uid_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                        size_t * indx,
                                        struct mailimap_msg_att_static ** result,
                                        size_t progr_rate,
@@ -8272,13 +8297,13 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_MSG_ATT_ERROR; /* XXX - removes a gcc warning */
 
-  r = mailimap_msg_att_envelope_parse(fd, buffer, &cur_token, &env,
+  r = mailimap_msg_att_envelope_parse(fd, buffer, parser_ctx, &cur_token, &env,
 				      progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_MSG_ATT_ENVELOPE;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_internaldate_parse(fd, buffer, &cur_token,
+    r = mailimap_msg_att_internaldate_parse(fd, buffer, parser_ctx, &cur_token,
 					    &internal_date,
 					    progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -8286,7 +8311,7 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
   }
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_rfc822_parse_progress(fd, buffer, &cur_token,
+    r = mailimap_msg_att_rfc822_parse_progress(fd, buffer, parser_ctx, &cur_token,
                                                &rfc822, &length,
                                                progr_rate, progr_fun,
                                                body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
@@ -8295,14 +8320,14 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_rfc822_header_parse(fd, buffer, &cur_token,
+    r = mailimap_msg_att_rfc822_header_parse(fd, buffer, parser_ctx, &cur_token,
 					     &rfc822_header, &length,
 					     progr_rate, progr_fun);
     type = MAILIMAP_MSG_ATT_RFC822_HEADER;
   }
   
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_rfc822_text_parse_progress(fd, buffer, &cur_token,
+    r = mailimap_msg_att_rfc822_text_parse_progress(fd, buffer, parser_ctx, &cur_token,
                                                     &rfc822_text, &length,
                                                     progr_rate, progr_fun,
                                                     body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
@@ -8311,21 +8336,21 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_rfc822_size_parse(fd, buffer, &cur_token,
+    r = mailimap_msg_att_rfc822_size_parse(fd, buffer, parser_ctx, &cur_token,
 					   &rfc822_size);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MSG_ATT_RFC822_SIZE;
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_body_parse(fd, buffer, &cur_token,
+    r = mailimap_msg_att_body_parse(fd, buffer, parser_ctx, &cur_token,
 				    &body, progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MSG_ATT_BODY;
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_bodystructure_parse(fd, buffer, &cur_token,
+    r = mailimap_msg_att_bodystructure_parse(fd, buffer, parser_ctx, &cur_token,
 					     &bodystructure,
 					     progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -8333,7 +8358,7 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_body_section_parse_progress(fd, buffer, &cur_token,
+    r = mailimap_msg_att_body_section_parse_progress(fd, buffer, parser_ctx, &cur_token,
                                                      &body_section,
                                                      progr_rate, progr_fun,
                                                      body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
@@ -8342,7 +8367,7 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_msg_att_uid_parse(fd, buffer, &cur_token,
+    r = mailimap_msg_att_uid_parse(fd, buffer, parser_ctx, &cur_token,
 				   &uid);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_MSG_ATT_UID;
@@ -8393,7 +8418,7 @@ mailimap_msg_att_static_parse_progress(mailstream * fd, MMAPString * buffer,
    nil             = "NIL"
 */
 
-int mailimap_nil_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_nil_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                        size_t * indx)
 {
   return mailimap_token_case_insensitive_parse(fd, buffer, indx, "NIL");
@@ -8403,7 +8428,7 @@ int mailimap_nil_parse(mailstream * fd, MMAPString * buffer,
    nstring         = string / nil
 */
 
-static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer,
+static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                            size_t * indx, char ** result,
                                            size_t * result_len,
                                            size_t progr_rate,
@@ -8416,7 +8441,7 @@ static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer,
 {
   int r;
   
-  r = mailimap_string_parse_progress(fd, buffer, indx, result, result_len,
+  r = mailimap_string_parse_progress(fd, buffer, parser_ctx, indx, result, result_len,
                                      progr_rate, progr_fun,
                                      body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   switch (r) {
@@ -8424,7 +8449,7 @@ static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer,
       return MAILIMAP_NO_ERROR;
       
     case MAILIMAP_ERROR_PARSE:
-      r = mailimap_nil_parse(fd, buffer, indx);
+      r = mailimap_nil_parse(fd, buffer, parser_ctx, indx);
       if (r != MAILIMAP_NO_ERROR) {
         return r;
       }
@@ -8439,13 +8464,13 @@ static int mailimap_nstring_parse_progress(mailstream * fd, MMAPString * buffer,
   }
 }
 
-int mailimap_nstring_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_nstring_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx, char ** result,
 				  size_t * result_len,
 				  size_t progr_rate,
 				  progress_function * progr_fun)
 {
-  return mailimap_nstring_parse_progress(fd, buffer, indx, result, result_len, progr_rate, progr_fun,
+  return mailimap_nstring_parse_progress(fd, buffer, parser_ctx, indx, result, result_len, progr_rate, progr_fun,
                                          NULL, NULL, NULL, NULL, NULL);
 }
 
@@ -8513,7 +8538,7 @@ mailimap_number_parse(mailstream * fd, MMAPString * buffer,
 */
 
 int
-mailimap_nz_number_parse(mailstream * fd, MMAPString * buffer,
+mailimap_nz_number_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 size_t * indx, uint32_t * result)
 {
 #ifdef UNSTRICT_SYNTAX
@@ -8540,7 +8565,7 @@ mailimap_nz_number_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
 
-  r = mailimap_digit_nz_parse(fd, buffer, &cur_token, &digit);
+  r = mailimap_digit_nz_parse(fd, buffer, parser_ctx, &cur_token, &digit);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -8574,7 +8599,7 @@ mailimap_nz_number_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_quoted_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quoted_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		      size_t * indx, char ** result,
 		      size_t progr_rate,
 		      progress_function * progr_fun)
@@ -8593,7 +8618,7 @@ mailimap_quoted_parse(mailstream * fd, MMAPString * buffer,
     return r;
 #endif
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -8619,7 +8644,7 @@ mailimap_quoted_parse(mailstream * fd, MMAPString * buffer,
       }
     }
     
-    r = mailimap_quoted_char_parse(fd, buffer, &cur_token, &ch);
+    r = mailimap_quoted_char_parse(fd, buffer, parser_ctx, &cur_token, &ch);
     if (r == MAILIMAP_ERROR_PARSE)
       break;
     else if (r == MAILIMAP_NO_ERROR) {
@@ -8634,7 +8659,7 @@ mailimap_quoted_parse(mailstream * fd, MMAPString * buffer,
     }
   }
 
-  r = mailimap_dquote_parse(fd, buffer, &cur_token);
+  r = mailimap_dquote_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -8664,7 +8689,7 @@ mailimap_quoted_parse(mailstream * fd, MMAPString * buffer,
 static int is_quoted_specials(char ch);
 
 int
-mailimap_quoted_char_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quoted_char_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			   size_t * indx, char * result)
 {
   size_t cur_token;
@@ -8689,7 +8714,7 @@ mailimap_quoted_char_parse(mailstream * fd, MMAPString * buffer,
       return r;
     }
 
-    r = mailimap_quoted_specials_parse(fd, buffer, &cur_token,
+    r = mailimap_quoted_specials_parse(fd, buffer, parser_ctx, &cur_token,
 				       &quoted_special);
     if (r != MAILIMAP_NO_ERROR) {
       * result = '\\';
@@ -8717,7 +8742,7 @@ static int is_quoted_specials(char ch)
 }
 
 static int
-mailimap_quoted_specials_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quoted_specials_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, char * result)
 {
   size_t cur_token;
@@ -8752,7 +8777,7 @@ mailimap_quoted_specials_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_cont_req_or_resp_data_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_cont_req_or_resp_data_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                               size_t * indx,
                                               struct mailimap_cont_req_or_resp_data **
                                               result,
@@ -8780,7 +8805,7 @@ mailimap_cont_req_or_resp_data_parse_progress(mailstream * fd, MMAPString * buff
 
   // skip blank lines (workaround for exchange)
   while (1) {
-    r = mailimap_crlf_parse(fd, buffer, &cur_token);
+    r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
     if (r == MAILIMAP_NO_ERROR) {
       if (fd == NULL) {
         if (!has_crlf(buffer, cur_token)) {
@@ -8797,13 +8822,13 @@ mailimap_cont_req_or_resp_data_parse_progress(mailstream * fd, MMAPString * buff
     break;
   }
   
-  r = mailimap_continue_req_parse(fd, buffer, &cur_token, &cont_req,
+  r = mailimap_continue_req_parse(fd, buffer, parser_ctx, &cur_token, &cont_req,
 				  progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_RESP_CONT_REQ;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_response_data_parse_progress(fd, buffer, &cur_token, &resp_data,
+    r = mailimap_response_data_parse_progress(fd, buffer, parser_ctx, &cur_token, &resp_data,
                                               progr_rate, progr_fun,
                                               body_progr_fun, items_progr_fun,
                                               context, msg_att_handler, msg_att_context);
@@ -8860,14 +8885,14 @@ mailimap_cont_req_or_resp_data_parse_progress(mailstream * fd, MMAPString * buff
 }
 
 /* static */ int
-mailimap_cont_req_or_resp_data_parse(mailstream * fd, MMAPString * buffer,
+mailimap_cont_req_or_resp_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                      size_t * indx,
                                      struct mailimap_cont_req_or_resp_data **
                                      result,
                                      size_t progr_rate,
                                      progress_function * progr_fun)
 {
-  return mailimap_cont_req_or_resp_data_parse_progress(fd, buffer, indx, result,
+  return mailimap_cont_req_or_resp_data_parse_progress(fd, buffer, parser_ctx, indx, result,
                                                        progr_rate,
                                                        progr_fun,
                                                        NULL, NULL, NULL, NULL, NULL);
@@ -8878,7 +8903,7 @@ mailimap_cont_req_or_resp_data_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_response_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_response_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                  size_t * indx, struct mailimap_response ** result,
                                  size_t progr_rate,
                                  progress_function * progr_fun,
@@ -8900,7 +8925,7 @@ mailimap_response_parse_progress(mailstream * fd, MMAPString * buffer,
   cont_req_or_resp_data_list = NULL;
   resp_done = NULL;
   
-  r = mailimap_struct_multiple_parse_progress(fd, buffer,
+  r = mailimap_struct_multiple_parse_progress(fd, buffer, parser_ctx,
                                               &cur_token, &cont_req_or_resp_data_list,
                                               (mailimap_struct_parser_progress *)
                                               mailimap_cont_req_or_resp_data_parse_progress,
@@ -8929,7 +8954,7 @@ mailimap_response_parse_progress(mailstream * fd, MMAPString * buffer,
     }
   }
   
-  r = mailimap_response_done_parse(fd, buffer, &cur_token, &resp_done,
+  r = mailimap_response_done_parse(fd, buffer, parser_ctx, &cur_token, &resp_done,
                                    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -8959,7 +8984,7 @@ free_list:
 }
 
 int
-mailimap_response_parse_with_context(mailstream * fd, MMAPString * buffer,
+mailimap_response_parse_with_context(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                      size_t * indx, struct mailimap_response ** result,
                                      mailprogress_function * body_progr_fun,
                                      mailprogress_function * items_progr_fun,
@@ -8967,19 +8992,19 @@ mailimap_response_parse_with_context(mailstream * fd, MMAPString * buffer,
                                      mailimap_msg_att_handler * msg_att_handler,
                                      void * msg_att_context)
 {
-  return mailimap_response_parse_progress(fd, buffer, indx, result,
+  return mailimap_response_parse_progress(fd, buffer, parser_ctx, indx, result,
                                           4096, NULL,
                                           body_progr_fun, items_progr_fun, context,
                                           msg_att_handler, msg_att_context);
 }
 
 int
-mailimap_response_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			size_t * indx, struct mailimap_response ** result,
 			size_t progr_rate,
 			progress_function * progr_fun)
 {
-  return mailimap_response_parse_progress(fd, buffer, indx, result,
+  return mailimap_response_parse_progress(fd, buffer, parser_ctx, indx, result,
                                           progr_rate, progr_fun,
                                           NULL, NULL, NULL, NULL, NULL);
 }
@@ -8990,7 +9015,7 @@ mailimap_response_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                       size_t * indx,
                                       struct mailimap_response_data ** result,
                                       size_t progr_rate,
@@ -9023,7 +9048,7 @@ mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_star_parse(fd, buffer, &cur_token);
+  r = mailimap_star_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -9037,34 +9062,34 @@ mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_RESP_DATA_TYPE_ERROR; /* XXX - removes a gcc warning */
 
-  r = mailimap_resp_cond_state_parse(fd, buffer, &cur_token, &cond_state,
+  r = mailimap_resp_cond_state_parse(fd, buffer, parser_ctx, &cur_token, &cond_state,
 				     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_RESP_DATA_TYPE_COND_STATE;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_resp_cond_bye_parse(fd, buffer, &cur_token, &cond_bye,
+    r = mailimap_resp_cond_bye_parse(fd, buffer, parser_ctx, &cur_token, &cond_bye,
 				     progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_DATA_TYPE_COND_BYE;
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_mailbox_data_parse(fd, buffer, &cur_token, &mb_data,
+    r = mailimap_mailbox_data_parse(fd, buffer, parser_ctx, &cur_token, &mb_data,
 				    progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_DATA_TYPE_MAILBOX_DATA;
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_message_data_parse_progress(fd, buffer, &cur_token, &msg_data,
+    r = mailimap_message_data_parse_progress(fd, buffer, parser_ctx, &cur_token, &msg_data,
 				    progr_rate, progr_fun, body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_DATA_TYPE_MESSAGE_DATA;
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_capability_data_parse(fd, buffer, &cur_token, &cap_data,
+    r = mailimap_capability_data_parse(fd, buffer, parser_ctx, &cur_token, &cap_data,
 				       progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_DATA_TYPE_CAPABILITY_DATA;
@@ -9072,7 +9097,7 @@ mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
 
   if (r == MAILIMAP_ERROR_PARSE) {
     r = mailimap_extension_data_parse(MAILIMAP_EXTENDED_PARSER_RESPONSE_DATA,
-                fd, buffer, &cur_token, &ext_data, progr_rate, progr_fun);
+                fd, buffer, parser_ctx, &cur_token, &ext_data, progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_DATA_TYPE_EXTENSION_DATA;
   }
@@ -9085,7 +9110,7 @@ mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_crlf_parse(fd, buffer, &cur_token);
+  r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -9140,13 +9165,13 @@ mailimap_response_data_parse_progress(mailstream * fd, MMAPString * buffer,
 }
 
 int
-mailimap_response_data_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                              size_t * indx,
                              struct mailimap_response_data ** result,
                              size_t progr_rate,
                              progress_function * progr_fun)
 {
-  return mailimap_response_data_parse_progress(fd, buffer, indx, result,
+  return mailimap_response_data_parse_progress(fd, buffer, parser_ctx, indx, result,
                                                progr_rate, progr_fun,
                                                NULL, NULL, NULL, NULL, NULL);
 }
@@ -9156,7 +9181,7 @@ mailimap_response_data_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_response_done_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_done_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_response_done ** result,
 			     size_t progr_rate,
@@ -9177,13 +9202,13 @@ mailimap_response_done_parse(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_RESP_DONE_TYPE_ERROR; /* removes a gcc warning */
 
-  r = mailimap_response_tagged_parse(fd, buffer, &cur_token, &tagged,
+  r = mailimap_response_tagged_parse(fd, buffer, parser_ctx, &cur_token, &tagged,
 				     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_RESP_DONE_TYPE_TAGGED;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_response_fatal_parse(fd, buffer, &cur_token, &fatal,
+    r = mailimap_response_fatal_parse(fd, buffer, parser_ctx, &cur_token, &fatal,
 				      progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_DONE_TYPE_FATAL;
@@ -9220,7 +9245,7 @@ mailimap_response_done_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_response_fatal ** result,
 			      size_t progr_rate,
@@ -9234,7 +9259,7 @@ mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_star_parse(fd, buffer, &cur_token);
+  r = mailimap_star_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -9246,14 +9271,14 @@ mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_resp_cond_bye_parse(fd, buffer, &cur_token, &cond_bye,
+  r = mailimap_resp_cond_bye_parse(fd, buffer, parser_ctx, &cur_token, &cond_bye,
 				   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_crlf_parse(fd, buffer, &cur_token);
+  r = mailimap_crlf_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -9281,7 +9306,7 @@ mailimap_response_fatal_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_response_tagged ** result,
 			       size_t progr_rate,
@@ -9297,7 +9322,7 @@ mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   cond_state = NULL;
 
-  r = mailimap_tag_parse(fd, buffer, &cur_token, &tag,
+  r = mailimap_tag_parse(fd, buffer, parser_ctx, &cur_token, &tag,
 			 progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -9310,7 +9335,7 @@ mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer,
     goto free_tag;
   }
 
-  r = mailimap_resp_cond_state_parse(fd, buffer, &cur_token, &cond_state,
+  r = mailimap_resp_cond_state_parse(fd, buffer, parser_ctx, &cur_token, &cond_state,
 				     progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -9342,7 +9367,7 @@ mailimap_response_tagged_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_cond_auth_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_cond_auth_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_resp_cond_auth ** result,
 			      size_t progr_rate,
@@ -9382,7 +9407,7 @@ mailimap_resp_cond_auth_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_resp_text_parse(fd, buffer, &cur_token, &text,
+  r = mailimap_resp_text_parse(fd, buffer, parser_ctx, &cur_token, &text,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -9411,7 +9436,7 @@ mailimap_resp_cond_auth_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_resp_cond_bye ** result,
 			     size_t progr_rate,
@@ -9438,7 +9463,7 @@ mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_resp_text_parse(fd, buffer, &cur_token, &text,
+  r = mailimap_resp_text_parse(fd, buffer, parser_ctx, &cur_token, &text,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -9468,7 +9493,7 @@ mailimap_resp_cond_bye_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_cond_state_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_cond_state_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_resp_cond_state ** result,
 			       size_t progr_rate,
@@ -9496,7 +9521,7 @@ mailimap_resp_cond_state_parse(mailstream * fd, MMAPString * buffer,
     goto err;
   }
 
-  r = mailimap_resp_text_parse(fd, buffer, &cur_token, &text,
+  r = mailimap_resp_text_parse(fd, buffer, parser_ctx, &cur_token, &text,
 			       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -9541,7 +9566,7 @@ static int is_resp_specials(char ch)
 /* "[" resp-text-code "]" */
 
 static int
-mailimap_resp_text_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_resp_text_code_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					size_t * indx,
 					struct mailimap_resp_text_code **
 					result,
@@ -9555,21 +9580,21 @@ mailimap_resp_text_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
 
-  r = mailimap_obracket_parse(fd, buffer, &cur_token);
+  r = mailimap_obracket_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
   text_code = NULL;
-  r = mailimap_resp_text_code_parse(fd, buffer, &cur_token, &text_code,
+  r = mailimap_resp_text_code_parse(fd, buffer, parser_ctx, &cur_token, &text_code,
 				    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_cbracket_parse(fd, buffer, &cur_token);
+  r = mailimap_cbracket_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -9597,7 +9622,7 @@ mailimap_resp_text_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 size_t * indx,
 			 struct mailimap_resp_text ** result,
 			 size_t progr_rate,
@@ -9614,13 +9639,13 @@ mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer,
   text = NULL;
   text_code = NULL;
 
-  r = mailimap_resp_text_resp_text_code_parse(fd, buffer, &cur_token,
+  r = mailimap_resp_text_resp_text_code_parse(fd, buffer, parser_ctx, &cur_token,
 					      &text_code,
 					      progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE))
     return r;
 
-  r = mailimap_text_parse(fd, buffer, &cur_token, &text,
+  r = mailimap_text_parse(fd, buffer, parser_ctx, &cur_token, &text,
 			  progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE)) {
     res = r;
@@ -9662,7 +9687,7 @@ mailimap_resp_text_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_text_code_1_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_1_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				size_t * indx,
 				int * result)
 {
@@ -9693,7 +9718,7 @@ mailimap_resp_text_code_1_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_resp_text_code_badcharset_1_parse(mailstream * fd,
-					   MMAPString * buffer,
+					   MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					   size_t * indx,
 					   clist ** result,
 					   size_t progr_rate,
@@ -9712,13 +9737,13 @@ mailimap_resp_text_code_badcharset_1_parse(mailstream * fd,
     goto err;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &charset,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &charset,
 					(mailimap_struct_parser *)
 					mailimap_astring_parse,
 					(mailimap_struct_destructor *)
@@ -9729,7 +9754,7 @@ mailimap_resp_text_code_badcharset_1_parse(mailstream * fd,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto charset;
@@ -9752,7 +9777,7 @@ mailimap_resp_text_code_badcharset_1_parse(mailstream * fd,
 */
 
 static int
-mailimap_resp_text_code_badcharset_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_badcharset_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					 size_t * indx,
 					 clist ** result,
 					 size_t progr_rate,
@@ -9771,7 +9796,7 @@ mailimap_resp_text_code_badcharset_parse(mailstream * fd, MMAPString * buffer,
 
   charset = NULL;
 
-  r = mailimap_resp_text_code_badcharset_1_parse(fd, buffer, &cur_token,
+  r = mailimap_resp_text_code_badcharset_1_parse(fd, buffer, parser_ctx, &cur_token,
 						 &charset,
 						 progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE))
@@ -9789,7 +9814,7 @@ mailimap_resp_text_code_badcharset_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_resp_text_code_permanentflags_parse(mailstream * fd,
-					     MMAPString * buffer,
+					     MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 					     size_t * indx,
 					     clist ** result,
 					     size_t progr_rate,
@@ -9817,13 +9842,13 @@ mailimap_resp_text_code_permanentflags_parse(mailstream * fd,
     goto err;
   }
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
   
-  r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &flaglist,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &flaglist,
 					(mailimap_struct_parser *)
 					mailimap_flag_perm_parse,
 					(mailimap_struct_destructor *)
@@ -9834,7 +9859,7 @@ mailimap_resp_text_code_permanentflags_parse(mailstream * fd,
     goto err;
   }
   
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto free;
@@ -9860,7 +9885,7 @@ mailimap_resp_text_code_permanentflags_parse(mailstream * fd,
 */
 
 static int
-mailimap_resp_text_code_number_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_number_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				     size_t * indx,
 				     struct mailimap_resp_text_code ** result,
 				     size_t progr_rate,
@@ -9884,7 +9909,7 @@ mailimap_resp_text_code_number_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_nz_number_parse(fd, buffer, &cur_token, &number);
+  r = mailimap_nz_number_parse(fd, buffer, parser_ctx, &cur_token, &number);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -9934,12 +9959,12 @@ static int is_text_char_1(char ch)
 */
 
 static int
-mailimap_resp_text_code_other_2_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_other_2_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				      size_t * indx, char ** result,
 				      size_t progr_rate,
 				      progress_function * progr_fun)
 {
-  return mailimap_custom_string_parse(fd, buffer, indx, result,
+  return mailimap_custom_string_parse(fd, buffer, parser_ctx, indx, result,
 				      is_text_char_1);
 }
 
@@ -9948,7 +9973,7 @@ mailimap_resp_text_code_other_2_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_text_code_other_1_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_other_1_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				      size_t * indx,
 				      char ** result,
 				      size_t progr_rate,
@@ -9964,7 +9989,7 @@ mailimap_resp_text_code_other_1_parse(mailstream * fd, MMAPString * buffer,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_resp_text_code_other_2_parse(fd, buffer, &cur_token,
+  r = mailimap_resp_text_code_other_2_parse(fd, buffer, parser_ctx, &cur_token,
 					    &value,
 					    progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR)
@@ -9981,7 +10006,7 @@ mailimap_resp_text_code_other_1_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_text_code_other_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_other_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				    size_t * indx,
 				    struct mailimap_resp_text_code ** result,
 				    size_t progr_rate,
@@ -9998,14 +10023,14 @@ mailimap_resp_text_code_other_parse(mailstream * fd, MMAPString * buffer,
   atom = NULL;
   value = NULL;
 
-  r = mailimap_atom_parse(fd, buffer, &cur_token, &atom,
+  r = mailimap_atom_parse(fd, buffer, parser_ctx, &cur_token, &atom,
 			  progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_resp_text_code_other_1_parse(fd, buffer, &cur_token,
+  r = mailimap_resp_text_code_other_1_parse(fd, buffer, parser_ctx, &cur_token,
 					    &value, progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE)) {
     res = r;
@@ -10047,7 +10072,7 @@ mailimap_resp_text_code_other_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
+mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx,
 			      struct mailimap_resp_text_code ** result,
 			      size_t progr_rate,
@@ -10072,14 +10097,14 @@ mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
   permanentflags = NULL;
 
   type = MAILIMAP_RESP_TEXT_CODE_OTHER;
-  r = mailimap_resp_text_code_1_parse(fd, buffer, &cur_token, &type);
+  r = mailimap_resp_text_code_1_parse(fd, buffer, parser_ctx, &cur_token, &type);
   if (r == MAILIMAP_NO_ERROR) {
     /* do nothing */
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
 
-    r = mailimap_resp_text_code_badcharset_parse(fd, buffer, &cur_token,
+    r = mailimap_resp_text_code_badcharset_parse(fd, buffer, parser_ctx, &cur_token,
 						 &badcharset,
 						 progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -10088,7 +10113,7 @@ mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
   
   if (r == MAILIMAP_ERROR_PARSE) {
 
-    r = mailimap_capability_data_parse(fd, buffer, &cur_token,
+    r = mailimap_capability_data_parse(fd, buffer, parser_ctx, &cur_token,
 				       &cap_data,
 				       progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
@@ -10096,7 +10121,7 @@ mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_resp_text_code_permanentflags_parse(fd, buffer, &cur_token,
+    r = mailimap_resp_text_code_permanentflags_parse(fd, buffer, parser_ctx, &cur_token,
 						     &permanentflags,
 						     progr_rate,
 						     progr_fun);
@@ -10105,21 +10130,21 @@ mailimap_resp_text_code_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_resp_text_code_number_parse(fd, buffer, &cur_token,
+    r = mailimap_resp_text_code_number_parse(fd, buffer, parser_ctx, &cur_token,
 					     &resp_text_code,
 					     progr_rate, progr_fun);
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
     r = mailimap_extension_data_parse(MAILIMAP_EXTENDED_PARSER_RESP_TEXT_CODE,
-        fd, buffer, &cur_token, &ext_data,
+        fd, buffer, parser_ctx, &cur_token, &ext_data,
         progr_rate, progr_fun);
     if (r == MAILIMAP_NO_ERROR)
       type = MAILIMAP_RESP_TEXT_CODE_EXTENSION;
   }
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_resp_text_code_other_parse(fd, buffer, &cur_token,
+    r = mailimap_resp_text_code_other_parse(fd, buffer, parser_ctx, &cur_token,
 					    &resp_text_code,
 					    progr_rate, progr_fun);
   }
@@ -10195,7 +10220,7 @@ err:
 */
 
 static int
-mailimap_section_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx,
 		       struct mailimap_section ** result,
 		       size_t progr_rate,
@@ -10211,20 +10236,20 @@ mailimap_section_parse(mailstream * fd, MMAPString * buffer,
 
   section_spec = NULL;
 
-  r = mailimap_obracket_parse(fd, buffer, &cur_token);
+  r = mailimap_obracket_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_section_spec_parse(fd, buffer, &cur_token, &section_spec,
+  r = mailimap_section_spec_parse(fd, buffer, parser_ctx, &cur_token, &section_spec,
 				  progr_rate, progr_fun);
   if ((r != MAILIMAP_NO_ERROR) && (r != MAILIMAP_ERROR_PARSE)) {
     res = r;
     goto err;
   }
 
-  r = mailimap_cbracket_parse(fd, buffer, &cur_token);
+  r = mailimap_cbracket_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
@@ -10258,7 +10283,7 @@ mailimap_section_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       struct mailimap_section_msgtext ** result,
 			       size_t progr_rate,
@@ -10282,7 +10307,7 @@ mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer,
   }
 
   if (type == MAILIMAP_SECTION_MSGTEXT_HEADER_FIELDS) {
-    r = mailimap_header_list_parse(fd, buffer, &cur_token, &header_list,
+    r = mailimap_header_list_parse(fd, buffer, parser_ctx, &cur_token, &header_list,
 				   progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -10290,7 +10315,7 @@ mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer,
     }
   }
   else if (type == MAILIMAP_SECTION_MSGTEXT_HEADER_FIELDS_NOT) {
-    r = mailimap_header_list_parse(fd, buffer, &cur_token, &header_list,
+    r = mailimap_header_list_parse(fd, buffer, parser_ctx, &cur_token, &header_list,
 				   progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -10322,7 +10347,7 @@ mailimap_section_msgtext_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_section_part_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_part_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_section_part ** result,
 			    size_t progr_rate,
@@ -10337,7 +10362,7 @@ mailimap_section_part_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
   section_id = NULL;
 
-  r = mailimap_struct_list_parse(fd, buffer, &cur_token, &section_id, '.',
+  r = mailimap_struct_list_parse(fd, buffer, parser_ctx, &cur_token, &section_id, '.',
 				 (mailimap_struct_parser *)
 				 mailimap_nz_number_alloc_parse,
 				 (mailimap_struct_destructor *)
@@ -10371,7 +10396,7 @@ mailimap_section_part_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_section_spec ** result,
 			    size_t progr_rate,
@@ -10393,7 +10418,7 @@ mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
   section_part = NULL;
   section_text = NULL;
 
-  r = mailimap_section_msgtext_parse(fd, buffer, &cur_token,
+  r = mailimap_section_msgtext_parse(fd, buffer, parser_ctx, &cur_token,
 				     &section_msgtext,
 				     progr_rate, progr_fun);
   switch (r) {
@@ -10403,7 +10428,7 @@ mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
     
   case MAILIMAP_ERROR_PARSE:
     
-    r = mailimap_section_part_parse(fd, buffer, &cur_token,
+    r = mailimap_section_part_parse(fd, buffer, parser_ctx, &cur_token,
 				    &section_part,
 				    progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
@@ -10415,9 +10440,9 @@ mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
     
     type = MAILIMAP_SECTION_SPEC_SECTION_PART;
     
-    r = mailimap_dot_parse(fd, buffer, &cur_token);
+    r = mailimap_dot_parse(fd, buffer, parser_ctx, &cur_token);
     if (r == MAILIMAP_NO_ERROR) {
-      r = mailimap_section_text_parse(fd, buffer, &cur_token, &section_text,
+      r = mailimap_section_text_parse(fd, buffer, parser_ctx, &cur_token, &section_text,
 				      progr_rate, progr_fun);
       if (r == MAILIMAP_NO_ERROR) {
 	final_token = cur_token;
@@ -10469,7 +10494,7 @@ mailimap_section_spec_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_section_text_parse(mailstream * fd, MMAPString * buffer,
+mailimap_section_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_section_text ** result,
 			    size_t progr_rate,
@@ -10488,7 +10513,7 @@ mailimap_section_text_parse(mailstream * fd, MMAPString * buffer,
 
   type = MAILIMAP_SECTION_TEXT_ERROR; /* XXX - removes a gcc warning */
 
-  r = mailimap_section_msgtext_parse(fd, buffer, &cur_token, &section_msgtext,
+  r = mailimap_section_msgtext_parse(fd, buffer, parser_ctx, &cur_token, &section_msgtext,
 				     progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     type = MAILIMAP_SECTION_TEXT_SECTION_MSGTEXT;
@@ -10562,7 +10587,7 @@ mailimap_section_text_parse(mailstream * fd, MMAPString * buffer,
                      "UNSEEN"
 */
 
-int mailimap_status_att_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_status_att_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, int * result)
 {
   int type;
@@ -10598,7 +10623,7 @@ int mailimap_status_att_parse(mailstream * fd, MMAPString * buffer,
 */
 
 static int
-mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer,
+mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                size_t * indx, char ** result,
                                size_t * result_len,
                                size_t progr_rate,
@@ -10619,12 +10644,12 @@ mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer,
   string = NULL;
   len = 0;
   
-  r = mailimap_quoted_parse(fd, buffer, &cur_token, &string,
+  r = mailimap_quoted_parse(fd, buffer, parser_ctx, &cur_token, &string,
 			    progr_rate, progr_fun);
   if (r == MAILIMAP_NO_ERROR)
     len = strlen(string);
   else if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_literal_parse_progress(fd, buffer, &cur_token, &string, &len,
+    r = mailimap_literal_parse_progress(fd, buffer, parser_ctx, &cur_token, &string, &len,
 			       progr_rate, progr_fun, body_progr_fun, items_progr_fun, context, msg_att_handler, msg_att_context);
   }
 
@@ -10640,13 +10665,13 @@ mailimap_string_parse_progress(mailstream * fd, MMAPString * buffer,
 }
 
 int
-mailimap_string_parse(mailstream * fd, MMAPString * buffer,
+mailimap_string_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                       size_t * indx, char ** result,
                       size_t * result_len,
                       size_t progr_rate,
                       progress_function * progr_fun)
 {
-  return mailimap_string_parse_progress(fd, buffer, indx, result,
+  return mailimap_string_parse_progress(fd, buffer, parser_ctx, indx, result,
                                         result_len, progr_rate, progr_fun,
                                         NULL, NULL, NULL, NULL, NULL);
 }
@@ -10675,7 +10700,7 @@ static int is_tag_char(char ch)
    tag             = 1*<any ASTRING-CHAR except "+">
 */
 
-static int mailimap_tag_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_tag_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			      size_t * indx, char ** result,
 			      size_t progr_rate,
 			      progress_function * progr_fun)
@@ -10686,7 +10711,7 @@ static int mailimap_tag_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token = * indx;
 
-  r = mailimap_custom_string_parse(fd, buffer, &cur_token, &tag,
+  r = mailimap_custom_string_parse(fd, buffer, parser_ctx, &cur_token, &tag,
 				   is_tag_char);
   if (r != MAILIMAP_NO_ERROR)
     return r;
@@ -10701,12 +10726,12 @@ static int mailimap_tag_parse(mailstream * fd, MMAPString * buffer,
    text            = 1*TEXT-CHAR
 */
 
-static int mailimap_text_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_text_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, char ** result,
 			       size_t progr_rate,
 			       progress_function * progr_fun)
 {
-  return mailimap_custom_string_parse(fd, buffer, indx, result,
+  return mailimap_custom_string_parse(fd, buffer, parser_ctx, indx, result,
 				      is_text_char);
 }
 
@@ -10732,7 +10757,7 @@ static int is_text_char(char ch)
   2DIGIT
 */
 
-static int mailimap_2digit_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_2digit_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				 size_t * indx, int * result)
 {
 #ifndef UNSTRICT_SYNTAX
@@ -10782,7 +10807,7 @@ static int mailimap_2digit_parse(mailstream * fd, MMAPString * buffer,
                        ; Hours minutes seconds
 */
 
-static int mailimap_time_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_time_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       int * phour, int * pmin, int * psec)
 {
@@ -10794,23 +10819,23 @@ static int mailimap_time_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
 
-  r = mailimap_2digit_parse(fd, buffer, &cur_token, &hour);
+  r = mailimap_2digit_parse(fd, buffer, parser_ctx, &cur_token, &hour);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_colon_parse(fd, buffer, &cur_token);
+  r = mailimap_colon_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_2digit_parse(fd, buffer, &cur_token, &min);
+  r = mailimap_2digit_parse(fd, buffer, parser_ctx, &cur_token, &min);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_colon_parse(fd, buffer, &cur_token);
+  r = mailimap_colon_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
-  r = mailimap_2digit_parse(fd, buffer, &cur_token, &sec);
+  r = mailimap_2digit_parse(fd, buffer, parser_ctx, &cur_token, &sec);
   if (r != MAILIMAP_NO_ERROR)
     return r;
 
@@ -10834,10 +10859,10 @@ static int mailimap_time_parse(mailstream * fd, MMAPString * buffer,
                        ; Strictly ascending
 */
 
-int mailimap_uniqueid_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_uniqueid_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, uint32_t * result)
 {
-  return mailimap_nz_number_parse(fd, buffer, indx, result);
+  return mailimap_nz_number_parse(fd, buffer, parser_ctx, indx, result);
 }
 
 /*
@@ -10865,7 +10890,7 @@ int mailimap_uniqueid_parse(mailstream * fd, MMAPString * buffer,
                        ; The Universal Time zone is "+0000".
 */
 
-static int mailimap_zone_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_zone_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, int * result)
 {
   size_t cur_token;
@@ -10880,12 +10905,12 @@ static int mailimap_zone_parse(mailstream * fd, MMAPString * buffer,
   cur_token = * indx;
 
   sign = 1;
-  r = mailimap_plus_parse(fd, buffer, &cur_token);
+  r = mailimap_plus_parse(fd, buffer, parser_ctx, &cur_token);
   if (r == MAILIMAP_NO_ERROR)
     sign = 1;
 
   if (r == MAILIMAP_ERROR_PARSE) {
-    r = mailimap_minus_parse(fd, buffer, &cur_token);
+    r = mailimap_minus_parse(fd, buffer, parser_ctx, &cur_token);
     if (r == MAILIMAP_NO_ERROR)
       sign = -1;
   }
@@ -10915,7 +10940,7 @@ static int mailimap_zone_parse(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-int mailimap_uint64_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_uint64_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, uint64_t * result)
 {
   size_t cur_token;
@@ -10952,13 +10977,13 @@ int mailimap_uint64_parse(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-int mailimap_mod_sequence_value_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_mod_sequence_value_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, uint64_t * result)
 {
-  return mailimap_uint64_parse(fd, buffer, indx, result);
+  return mailimap_uint64_parse(fd, buffer, parser_ctx, indx, result);
 }
 
-static int mailimap_seq_number_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_seq_number_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, uint32_t * result)
 {
   int r;
@@ -10967,13 +10992,13 @@ static int mailimap_seq_number_parse(mailstream * fd, MMAPString * buffer,
 
   cur_token  = * indx;
   
-  r = mailimap_nz_number_parse(fd, buffer, &cur_token, &value);
+  r = mailimap_nz_number_parse(fd, buffer, parser_ctx, &cur_token, &value);
   if (r == MAILIMAP_NO_ERROR) {
     * indx = cur_token;
     * result = value;
     return MAILIMAP_NO_ERROR;
   }
-  r = mailimap_star_parse(fd, buffer, &cur_token);
+  r = mailimap_star_parse(fd, buffer, parser_ctx, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
     * indx = cur_token;
     * result = 0;
@@ -10983,7 +11008,7 @@ static int mailimap_seq_number_parse(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_ERROR_PARSE;
 }
 
-static int mailimap_seq_range_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_seq_range_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, uint32_t * result_left, uint32_t * result_right)
 {
   size_t cur_token;  
@@ -10992,17 +11017,17 @@ static int mailimap_seq_range_parse(mailstream * fd, MMAPString * buffer,
   uint32_t right;
 
   cur_token  = * indx;
-  r = mailimap_seq_number_parse(fd, buffer, &cur_token, &left);
+  r = mailimap_seq_number_parse(fd, buffer, parser_ctx, &cur_token, &left);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
   
-  r = mailimap_colon_parse(fd, buffer, &cur_token);
+  r = mailimap_colon_parse(fd, buffer, parser_ctx, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
   
-  r = mailimap_seq_number_parse(fd, buffer, &cur_token, &right);
+  r = mailimap_seq_number_parse(fd, buffer, parser_ctx, &cur_token, &right);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
@@ -11014,7 +11039,7 @@ static int mailimap_seq_range_parse(mailstream * fd, MMAPString * buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-static int mailimap_set_item_parse(mailstream * fd, MMAPString * buffer,
+static int mailimap_set_item_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, struct mailimap_set_item ** result,
   size_t progr_rate,
   progress_function * progr_fun)
@@ -11027,7 +11052,7 @@ static int mailimap_set_item_parse(mailstream * fd, MMAPString * buffer,
   
   cur_token = * indx;
   
-  r = mailimap_seq_range_parse(fd, buffer, &cur_token, &left, &right);
+  r = mailimap_seq_range_parse(fd, buffer, parser_ctx, &cur_token, &left, &right);
   if (r == MAILIMAP_NO_ERROR) {
     struct mailimap_set_item * item;
     
@@ -11040,7 +11065,7 @@ static int mailimap_set_item_parse(mailstream * fd, MMAPString * buffer,
     return MAILIMAP_NO_ERROR;
   }
   
-  r = mailimap_seq_number_parse(fd, buffer, &cur_token, &value);
+  r = mailimap_seq_number_parse(fd, buffer, parser_ctx, &cur_token, &value);
   if (r == MAILIMAP_NO_ERROR) {
     struct mailimap_set_item * item;
     
@@ -11057,7 +11082,7 @@ static int mailimap_set_item_parse(mailstream * fd, MMAPString * buffer,
 }
 
 int mailimap_set_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx, struct mailimap_set ** result)
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, struct mailimap_set ** result)
 {
   size_t cur_token;
   struct mailimap_set * set;
@@ -11066,7 +11091,7 @@ int mailimap_set_parse(mailstream * fd,
   
   cur_token = * indx;
   
-  r = mailimap_struct_list_parse(fd, buffer, &cur_token, &item_list,
+  r = mailimap_struct_list_parse(fd, buffer, parser_ctx, &cur_token, &item_list,
     ',', (mailimap_struct_parser *) mailimap_set_item_parse, (mailimap_struct_destructor *)mailimap_set_item_free,
     0, NULL);
   if (r != MAILIMAP_NO_ERROR)

--- a/src/low-level/imap/mailimap_parser.h
+++ b/src/low-level/imap/mailimap_parser.h
@@ -43,20 +43,20 @@ extern "C" {
 
 #include "mailimap_types.h"
 
-int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_greeting_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_greeting ** result,
 			    size_t progr_rate,
 			    progress_function * progr_fun);
 
 int
-mailimap_response_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			size_t * indx, struct mailimap_response ** result,
 			size_t progr_rate,
 			progress_function * progr_fun);
 
 int
-mailimap_response_parse_with_context(mailstream * fd, MMAPString * buffer,
+mailimap_response_parse_with_context(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                      size_t * indx, struct mailimap_response ** result,
                                      mailprogress_function * body_progr_fun,
                                      mailprogress_function * items_progr_fun,
@@ -65,20 +65,20 @@ mailimap_response_parse_with_context(mailstream * fd, MMAPString * buffer,
                                      void * msg_att_context);
   
 int
-mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer,
+mailimap_continue_req_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			    size_t * indx,
 			    struct mailimap_continue_req ** result,
 			    size_t progr_rate,
 			    progress_function * progr_fun);
 
 int
-mailimap_response_data_parse(mailstream * fd, MMAPString * buffer,
+mailimap_response_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			     size_t * indx,
 			     struct mailimap_response_data ** result,
 			     size_t progr_rate,
 			     progress_function * progr_fun);
 
-typedef int mailimap_struct_parser(mailstream * fd, MMAPString * buffer,
+typedef int mailimap_struct_parser(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx, void * result,
 				   size_t progr_rate,
 				   progress_function * progr_fun);
@@ -86,51 +86,51 @@ typedef int mailimap_struct_parser(mailstream * fd, MMAPString * buffer,
 typedef void mailimap_struct_destructor(void * result);
 
 int
-mailimap_mailbox_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx, char ** result,
 		       size_t progr_rate,
 		       progress_function * progr_fun);
 int
-mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                             size_t * indx,
                             struct mailimap_mailbox_list ** result,
                             size_t progr_rate,
                             progress_function * progr_fun);
   
-int mailimap_nstring_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_nstring_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx, char ** result,
 				  size_t * result_len,
 				  size_t progr_rate,
 				  progress_function * progr_fun);
 
 int
-mailimap_string_parse(mailstream * fd, MMAPString * buffer,
+mailimap_string_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		      size_t * indx, char ** result,
 		      size_t * result_len,
 		      size_t progr_rate,
 		      progress_function * progr_fun);
 
 int
-mailimap_struct_spaced_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_struct_spaced_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				  size_t * indx, clist ** result,
 				  mailimap_struct_parser * parser,
 				  mailimap_struct_destructor * destructor,
 				  size_t progr_rate,
 				  progress_function * progr_fun);
 
-int mailimap_oparenth_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_oparenth_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx);
 
-int mailimap_cparenth_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_cparenth_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 				   size_t * indx);
 
-int mailimap_atom_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_atom_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			size_t * indx, char ** result,
 			size_t progr_rate,
 			progress_function * progr_fun);
 
 int
-mailimap_astring_parse(mailstream * fd, MMAPString * buffer,
+mailimap_astring_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 		       size_t * indx,
 		       char ** result,
 		       size_t progr_rate,
@@ -141,11 +141,11 @@ mailimap_number_parse(mailstream * fd, MMAPString * buffer,
 		      size_t * indx, uint32_t * result);
 
 int
-mailimap_nz_number_parse(mailstream * fd, MMAPString * buffer,
+mailimap_nz_number_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			 size_t * indx, uint32_t * result);
 
 int
-mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
+mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, clist ** result,
     char symbol,
     mailimap_struct_parser * parser,
@@ -153,60 +153,60 @@ mailimap_struct_list_parse(mailstream * fd, MMAPString * buffer,
     size_t progr_rate,
     progress_function * progr_fun);
 
-int mailimap_uniqueid_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_uniqueid_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, uint32_t * result);
 
-int mailimap_colon_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_colon_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx);
 
-int mailimap_dquote_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_dquote_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                           size_t * indx);
 
 int
-mailimap_quoted_char_parse(mailstream * fd, MMAPString * buffer,
+mailimap_quoted_char_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                            size_t * indx, char * result);
   
-int mailimap_nil_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_nil_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                        size_t * indx);
 
 int
-mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer,
+mailimap_struct_multiple_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx, clist ** result,
 			       mailimap_struct_parser * parser,
 			       mailimap_struct_destructor * destructor,
 			       size_t progr_rate,
 			       progress_function * progr_fun);
 
-int mailimap_capability_data_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_capability_data_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 	size_t * indx,
 	struct mailimap_capability_data ** result,
 	size_t progr_rate,
 	progress_function * progr_fun);
 
 int mailimap_capability_list_parse(mailstream * fd,
-  MMAPString * buffer,
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx,
   clist ** result,
   size_t progr_rate,
   progress_function * progr_fun);
 
-int mailimap_status_att_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_status_att_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, int * result);
 
-int mailimap_nz_number_alloc_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_nz_number_alloc_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
 			       size_t * indx,
 			       uint32_t ** result,
 			       size_t progr_rate,
              progress_function * progr_fun);
 
-int mailimap_mod_sequence_value_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_mod_sequence_value_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, uint64_t * result);
 
-int mailimap_uint64_parse(mailstream * fd, MMAPString * buffer,
+int mailimap_uint64_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
   size_t * indx, uint64_t * result);
 
 int mailimap_set_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx, struct mailimap_set ** result);
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx, struct mailimap_set ** result);
 
 LIBETPAN_EXPORT
 int mailimap_hack_date_time_parse(char * str,

--- a/src/low-level/imap/mailimap_sort.c
+++ b/src/low-level/imap/mailimap_sort.c
@@ -60,7 +60,7 @@ int mailimap_sort_key_send(mailstream * fd,
 
 static int
 mailimap_sort_extension_parse(int calling_parser, mailstream * fd,
-                               MMAPString * buffer, size_t * indx,
+                               MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                struct mailimap_extension_data ** result,
                                size_t progr_rate, progress_function * progr_fun);
 
@@ -352,7 +352,7 @@ int mailimap_sort_key_send(mailstream * fd,
 }
 
 static int
-mailimap_number_list_data_sort_parse(mailstream * fd, MMAPString * buffer,
+mailimap_number_list_data_sort_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                      size_t * indx,
                                      clist ** result,
                                      size_t progr_rate,
@@ -375,7 +375,7 @@ mailimap_number_list_data_sort_parse(mailstream * fd, MMAPString * buffer,
   
   r = mailimap_space_parse(fd, buffer, &cur_token);
   if (r == MAILIMAP_NO_ERROR) {
-    r = mailimap_struct_spaced_list_parse(fd, buffer, &cur_token, &number_list,
+    r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx, &cur_token, &number_list,
                                           (mailimap_struct_parser *)
                                           mailimap_nz_number_alloc_parse,
                                           (mailimap_struct_destructor *)
@@ -394,7 +394,7 @@ mailimap_number_list_data_sort_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_sort_extension_parse(int calling_parser, mailstream * fd,
-                              MMAPString * buffer, size_t * indx,
+                              MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                               struct mailimap_extension_data ** result,
                               size_t progr_rate, progress_function * progr_fun)
 {
@@ -410,7 +410,7 @@ mailimap_sort_extension_parse(int calling_parser, mailstream * fd,
   {
     case MAILIMAP_EXTENDED_PARSER_RESPONSE_DATA:
     case MAILIMAP_EXTENDED_PARSER_MAILBOX_DATA:
-      r = mailimap_number_list_data_sort_parse(fd, buffer, &cur_token,
+      r = mailimap_number_list_data_sort_parse(fd, buffer, NULL, &cur_token,
                                                &number_list, progr_rate, progr_fun);
       if (r == MAILIMAP_NO_ERROR) {
         data = number_list;

--- a/src/low-level/imap/mailimap_types.c
+++ b/src/low-level/imap/mailimap_types.c
@@ -41,6 +41,7 @@
 #include "mmapstring.h"
 #include "mail.h"
 #include "mailimap_extension.h"
+#include "mailimap.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -3234,4 +3235,37 @@ mailimap_response_info_free(struct mailimap_response_info * resp_info)
   }
 
   free(resp_info);
+}
+
+
+LIBETPAN_EXPORT
+int
+mailimap_parser_context_is_rambler_workaround_enabled(struct mailimap_parser_context * parser_ctx)
+{
+  return parser_ctx != NULL && parser_ctx->is_rambler_workaround_enabled;
+}
+
+LIBETPAN_EXPORT
+struct mailimap_parser_context *
+mailimap_parser_context_new(mailimap * session)
+{
+  struct mailimap_parser_context * ctx;
+
+  ctx = malloc(sizeof(* ctx));
+  if (ctx == NULL)
+    goto err;
+
+  ctx->is_rambler_workaround_enabled = mailimap_is_rambler_workaround_enabled(session);
+
+  return ctx;
+
+err:
+  return NULL;
+}
+
+LIBETPAN_EXPORT
+void
+mailimap_parser_context_free(struct mailimap_parser_context * ctx)
+{
+  free(ctx);
 }

--- a/src/low-level/imap/mailimap_types.h
+++ b/src/low-level/imap/mailimap_types.h
@@ -3387,6 +3387,7 @@ struct mailimap {
   void * imap_logger_context;
   
   int is_163_workaround_enabled;
+  int is_rambler_workaround_enabled;
 };
 
 
@@ -3566,6 +3567,23 @@ enum {
   MAILIMAP_ERROR_CUSTOM_COMMAND
 };
 
+/* information about parser context */
+
+struct mailimap_parser_context {
+  int is_rambler_workaround_enabled;
+};
+
+LIBETPAN_EXPORT
+struct mailimap_parser_context *
+mailimap_parser_context_new(mailimap * session);
+
+LIBETPAN_EXPORT
+void
+mailimap_parser_context_free(struct mailimap_parser_context * ctx);
+
+LIBETPAN_EXPORT
+int
+mailimap_parser_context_is_rambler_workaround_enabled(struct mailimap_parser_context * parser_ctx);
 
 #ifdef __cplusplus
 }

--- a/src/low-level/imap/namespace_parser.h
+++ b/src/low-level/imap/namespace_parser.h
@@ -44,7 +44,7 @@ extern "C" {
 
 int
 mailimap_namespace_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun);
 

--- a/src/low-level/imap/qresync.c
+++ b/src/low-level/imap/qresync.c
@@ -87,7 +87,7 @@ static void
 
 static int
 	mailimap_qresync_extension_parse(int calling_parser, mailstream * fd,
-	MMAPString * buffer, size_t * indx,
+	MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 	struct mailimap_extension_data ** result,
 	size_t progr_rate, progress_function * progr_fun);
 
@@ -538,16 +538,16 @@ static void
 }
 
 static int resp_text_code_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx,
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
   struct mailimap_qresync_resptextcode ** result);
 
 static int vanished_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx,
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
   struct mailimap_qresync_vanished ** result);
 
 static int
 	mailimap_qresync_extension_parse(int calling_parser, mailstream * fd,
-	MMAPString * buffer, size_t * indx,
+	MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
 	struct mailimap_extension_data ** result,
 	size_t progr_rate, progress_function * progr_fun)
 {
@@ -561,7 +561,7 @@ static int
       struct mailimap_qresync_resptextcode * resptextcode;
       struct mailimap_extension_data * ext_data;
       
-      r = resp_text_code_parse(fd, buffer, &cur_token, &resptextcode);
+      r = resp_text_code_parse(fd, buffer, parser_ctx, &cur_token, &resptextcode);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       ext_data = mailimap_extension_data_new(&mailimap_extension_qresync,
@@ -579,7 +579,7 @@ static int
       struct mailimap_qresync_vanished * vanished;
       struct mailimap_extension_data * ext_data;
       
-      r = vanished_parse(fd, buffer, &cur_token, &vanished);
+      r = vanished_parse(fd, buffer, parser_ctx, &cur_token, &vanished);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       ext_data = mailimap_extension_data_new(&mailimap_extension_qresync,
@@ -598,7 +598,7 @@ static int
 }
 
 static int resp_text_code_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx,
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
   struct mailimap_qresync_resptextcode ** result)
 {
   int r;
@@ -628,7 +628,7 @@ expunged-resp       =  "VANISHED" [SP "(EARLIER)"] SP known-uids
 */
 
 static int vanished_parse(mailstream * fd,
-  MMAPString * buffer, size_t * indx,
+  MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
   struct mailimap_qresync_vanished ** result)
 {
   int r;
@@ -664,7 +664,7 @@ static int vanished_parse(mailstream * fd,
     }
   }
   
-  r = mailimap_set_parse(fd, buffer, &cur_token, &set);
+  r = mailimap_set_parse(fd, buffer, parser_ctx, &cur_token, &set);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;

--- a/src/low-level/imap/quota_parser.c
+++ b/src/low-level/imap/quota_parser.c
@@ -42,7 +42,7 @@
 #include <stdlib.h>
 
 int
-mailimap_quota_quota_resource_parse(mailstream * fd, MMAPString *buffer,
+mailimap_quota_quota_resource_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
     size_t * indx, void * result_ptr,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -53,7 +53,7 @@ mailimap_quota_quota_resource_parse(mailstream * fd, MMAPString *buffer,
   uint32_t usage, limit;
   struct mailimap_quota_quota_resource * resource;
 
-  r = mailimap_atom_parse(fd, buffer, &cur_token, &resource_name,
+  r = mailimap_atom_parse(fd, buffer, parser_ctx, &cur_token, &resource_name,
       progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -102,8 +102,8 @@ mailimap_quota_quota_resource_parse(mailstream * fd, MMAPString *buffer,
   return res;
 }
 
-int
-mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString *buffer,
+static int
+mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString * buffer,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -114,13 +114,13 @@ mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString *buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, NULL, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto err;
   }
 
-  r = mailimap_struct_spaced_list_parse(fd, buffer,
+  r = mailimap_struct_spaced_list_parse(fd, buffer, NULL,
       &cur_token, &quota_resource_list,
       &mailimap_quota_quota_resource_parse,
       (mailimap_struct_destructor *)
@@ -131,7 +131,7 @@ mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, NULL, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
     goto quota_list_free;
@@ -150,8 +150,8 @@ mailimap_quota_quota_list_nonempty_parse(mailstream * fd, MMAPString *buffer,
   return res;
 }
 
-int
-mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString *buffer,
+static int
+mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString * buffer,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -161,12 +161,12 @@ mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString *buffer,
 
   cur_token = * indx;
 
-  r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_oparenth_parse(fd, buffer, NULL, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
 
-  r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+  r = mailimap_cparenth_parse(fd, buffer, NULL, &cur_token);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
   }
@@ -182,8 +182,8 @@ mailimap_quota_quota_list_empty_parse(mailstream * fd, MMAPString *buffer,
   return MAILIMAP_NO_ERROR;
 }
 
-int
-mailimap_quota_quota_list_parse(mailstream * fd, MMAPString *buffer,
+static int
+mailimap_quota_quota_list_parse(mailstream * fd, MMAPString * buffer,
     size_t * indx, clist ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -199,8 +199,8 @@ mailimap_quota_quota_list_parse(mailstream * fd, MMAPString *buffer,
       progr_rate, progr_fun);
 }
 
-int
-mailimap_quota_quota_response_parse(mailstream * fd, MMAPString *buffer,
+static int
+mailimap_quota_quota_response_parse(mailstream * fd, MMAPString * buffer,
     size_t * indx, struct mailimap_quota_quota_data ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -226,7 +226,7 @@ mailimap_quota_quota_response_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_astring_parse(fd, buffer, &cur_token, &quotaroot,
+  r = mailimap_astring_parse(fd, buffer, NULL, &cur_token, &quotaroot,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -267,8 +267,8 @@ mailimap_quota_quota_response_parse(mailstream * fd, MMAPString *buffer,
   return res;
 }
 
-int
-mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString *buffer,
+static int
+mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString * buffer,
     size_t * indx, struct mailimap_quota_quotaroot_data ** result,
     size_t progr_rate, progress_function * progr_fun)
 {
@@ -295,7 +295,7 @@ mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString *buffer,
     goto err;
   }
 
-  r = mailimap_mailbox_parse(fd, buffer, &cur_token, &mailbox,
+  r = mailimap_mailbox_parse(fd, buffer, NULL, &cur_token, &mailbox,
           progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     res = r;
@@ -317,7 +317,7 @@ mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString *buffer,
       goto quotaroot_list_free;
     }
 
-    r = mailimap_astring_parse(fd, buffer, &cur_token, &quotaroot,
+    r = mailimap_astring_parse(fd, buffer, NULL, &cur_token, &quotaroot,
         progr_rate, progr_fun);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
@@ -372,7 +372,7 @@ mailimap_quota_quotaroot_response_parse(mailstream * fd, MMAPString *buffer,
   is identical in either case)
 */
 int mailimap_quota_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun)

--- a/src/low-level/imap/quota_parser.h
+++ b/src/low-level/imap/quota_parser.h
@@ -42,7 +42,7 @@ extern "C" {
 
 int
 mailimap_quota_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate, progress_function * progr_fun);
 

--- a/src/low-level/imap/uidplus_parser.h
+++ b/src/low-level/imap/uidplus_parser.h
@@ -43,7 +43,7 @@ extern "C" {
 #include "mailimap_extension_types.h"
 
 int mailimap_uidplus_parse(int calling_parser, mailstream * fd,
-    MMAPString * buffer, size_t * indx,
+    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
     struct mailimap_extension_data ** result,
     size_t progr_rate,
     progress_function * progr_fun);

--- a/src/low-level/imap/xgmlabels.c
+++ b/src/low-level/imap/xgmlabels.c
@@ -118,7 +118,7 @@ enum {
 
 static int
 mailimap_xgmlabels_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun);
 
@@ -134,7 +134,7 @@ struct mailimap_extension_api mailimap_extension_xgmlabels = {
 };
 
 static int mailimap_xgmlabels_parse(mailstream * fd,
-                                    MMAPString * buffer, size_t * indx,
+                                    MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                     clist ** result)
 {
     size_t cur_token;
@@ -144,13 +144,13 @@ static int mailimap_xgmlabels_parse(mailstream * fd,
     
     cur_token = * indx;
     
-    r = mailimap_oparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_oparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto err;
     }
     
-    r = mailimap_struct_spaced_list_parse(fd, buffer,
+    r = mailimap_struct_spaced_list_parse(fd, buffer, parser_ctx,
                                           &cur_token, &list,
                                           (mailimap_struct_parser * ) mailimap_astring_parse,
                                           (mailimap_struct_destructor * ) mailimap_astring_free,
@@ -167,7 +167,7 @@ static int mailimap_xgmlabels_parse(mailstream * fd,
       goto err;
     }
     
-    r = mailimap_cparenth_parse(fd, buffer, &cur_token);
+    r = mailimap_cparenth_parse(fd, buffer, parser_ctx, &cur_token);
     if (r != MAILIMAP_NO_ERROR) {
       res = r;
       goto free_list;
@@ -186,7 +186,7 @@ err:
 }
 
 static int fetch_data_xgmlabels_parse(mailstream * fd,
-                                      MMAPString * buffer, size_t * indx,
+                                      MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                       struct mailimap_msg_att_xgmlabels ** result)
 {
   size_t cur_token;
@@ -205,7 +205,7 @@ static int fetch_data_xgmlabels_parse(mailstream * fd,
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
-  r = mailimap_xgmlabels_parse(fd, buffer, &cur_token, &label_list);
+  r = mailimap_xgmlabels_parse(fd, buffer, parser_ctx, &cur_token, &label_list);
   if (r != MAILIMAP_NO_ERROR)
     return r;
   
@@ -224,7 +224,7 @@ static int fetch_data_xgmlabels_parse(mailstream * fd,
 
 static int
 mailimap_xgmlabels_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun)
 {
@@ -241,7 +241,7 @@ mailimap_xgmlabels_extension_parse(int calling_parser, mailstream * fd,
   {
     case MAILIMAP_EXTENDED_PARSER_FETCH_DATA:
       att = NULL;
-      r = fetch_data_xgmlabels_parse(fd, buffer, &cur_token, &att);
+      r = fetch_data_xgmlabels_parse(fd, buffer, parser_ctx, &cur_token, &att);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       

--- a/src/low-level/imap/xgmmsgid.c
+++ b/src/low-level/imap/xgmmsgid.c
@@ -48,7 +48,7 @@ enum {
 
 static int
 mailimap_xgmmsgid_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun);
 
@@ -64,7 +64,7 @@ struct mailimap_extension_api mailimap_extension_xgmmsgid = {
 };
 
 static int fetch_data_xgmmsgid_parse(mailstream * fd,
-                                      MMAPString * buffer, size_t * indx,
+                                      MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                       uint64_t * result, size_t progr_rate, progress_function * progr_fun)
 {
     size_t cur_token;
@@ -82,7 +82,7 @@ static int fetch_data_xgmmsgid_parse(mailstream * fd,
     if (r != MAILIMAP_NO_ERROR)
         return r;
     
-    r = mailimap_uint64_parse(fd, buffer, &cur_token, &msgid);
+    r = mailimap_uint64_parse(fd, buffer, parser_ctx, &cur_token, &msgid);
     if (r != MAILIMAP_NO_ERROR)
         return r;
     
@@ -94,7 +94,7 @@ static int fetch_data_xgmmsgid_parse(mailstream * fd,
 
 static int
 mailimap_xgmmsgid_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun)
 {
@@ -110,7 +110,7 @@ mailimap_xgmmsgid_extension_parse(int calling_parser, mailstream * fd,
     {
         case MAILIMAP_EXTENDED_PARSER_FETCH_DATA:
             
-            r = fetch_data_xgmmsgid_parse(fd, buffer, &cur_token, &msgid, progr_rate, progr_fun);
+            r = fetch_data_xgmmsgid_parse(fd, buffer, parser_ctx, &cur_token, &msgid, progr_rate, progr_fun);
             if (r != MAILIMAP_NO_ERROR)
               return r;
             

--- a/src/low-level/imap/xgmthrid.c
+++ b/src/low-level/imap/xgmthrid.c
@@ -48,7 +48,7 @@ enum {
 
 static int
 mailimap_xgmthrid_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun);
 
@@ -82,7 +82,7 @@ static int fetch_data_xgmthrid_parse(mailstream * fd,
     if (r != MAILIMAP_NO_ERROR)
         return r;
     
-    r = mailimap_uint64_parse(fd, buffer, &cur_token, &thrid);
+    r = mailimap_uint64_parse(fd, buffer, NULL, &cur_token, &thrid);
     if (r != MAILIMAP_NO_ERROR)
         return r;
     
@@ -94,7 +94,7 @@ static int fetch_data_xgmthrid_parse(mailstream * fd,
 
 static int
 mailimap_xgmthrid_extension_parse(int calling_parser, mailstream * fd,
-                                   MMAPString * buffer, size_t * indx,
+                                   MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                    struct mailimap_extension_data ** result,
                                    size_t progr_rate, progress_function * progr_fun)
 {

--- a/src/low-level/imap/xlist.c
+++ b/src/low-level/imap/xlist.c
@@ -44,7 +44,7 @@ enum {
 
 static int
 mailimap_xlist_extension_parse(int calling_parser, mailstream * fd,
-                               MMAPString * buffer, size_t * indx,
+                               MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                struct mailimap_extension_data ** result,
                                size_t progr_rate, progress_function * progr_fun);
 
@@ -187,7 +187,7 @@ free_response:
 }
 
 static int
-mailimap_mailbox_data_xlist_parse(mailstream * fd, MMAPString * buffer,
+mailimap_mailbox_data_xlist_parse(mailstream * fd, MMAPString * buffer, struct mailimap_parser_context * parser_ctx,
                                   size_t * indx,
                                   struct mailimap_mailbox_list ** result,
                                   size_t progr_rate,
@@ -209,7 +209,7 @@ mailimap_mailbox_data_xlist_parse(mailstream * fd, MMAPString * buffer,
     return r;
   }
   
-  r = mailimap_mailbox_list_parse(fd, buffer, &cur_token, &mb_list,
+  r = mailimap_mailbox_list_parse(fd, buffer, parser_ctx, &cur_token, &mb_list,
                                   progr_rate, progr_fun);
   if (r != MAILIMAP_NO_ERROR) {
     return r;
@@ -223,7 +223,7 @@ mailimap_mailbox_data_xlist_parse(mailstream * fd, MMAPString * buffer,
 
 static int
 mailimap_xlist_extension_parse(int calling_parser, mailstream * fd,
-                               MMAPString * buffer, size_t * indx,
+                               MMAPString * buffer, struct mailimap_parser_context * parser_ctx, size_t * indx,
                                struct mailimap_extension_data ** result,
                                size_t progr_rate, progress_function * progr_fun)
 {
@@ -239,7 +239,7 @@ mailimap_xlist_extension_parse(int calling_parser, mailstream * fd,
   switch (calling_parser)
   {
     case MAILIMAP_EXTENDED_PARSER_RESPONSE_DATA:
-      r = mailimap_mailbox_data_xlist_parse(fd, buffer, &cur_token,
+      r = mailimap_mailbox_data_xlist_parse(fd, buffer, parser_ctx, &cur_token,
                                             &xlist_data, progr_rate, progr_fun);
       if (r == MAILIMAP_NO_ERROR) {
         type = MAILIMAP_XLIST_TYPE_XLIST;


### PR DESCRIPTION
Occasionally, for large attachments (~20MB) Rambler returns wrong length of the literal.

See example below (real example attached):

C: 1 UID FETCH 2 BODY.PEEK[2]
S: * 140 FETCH (BODY[2] {100}\r\n
     123456789 UID 2)\r\n
S: 1 OK completed\r\n

As you can see server states '100' as a length of the literal, but provides only 9 bytes.

Mailcore2 awaits exactly '100' bytes and ignores the fact that server has completed his response.

Two issues arise in result:

* Response will not be parsed as it's size < 100 bytes. Mailcore2 will wait for the remaining bytes with no result and block one connection from the pool for 30 seconds (timeout).
* Number of subsequent requests with urgent=NO may be placed into hanged connection queue.