### PR TITLE
fix typo in return code

### DIFF
--- a/src/low-level/feed/parser.c
+++ b/src/low-level/feed/parser.c
@@ -230,7 +230,7 @@ static int iconv_utf32_char(iconv_t cd, const char * inbuf, size_t insize,
     return LEP_ICONV_OK;
   }
 #else
-  return LEP_ICONV_FAIL;
+  return LEP_ICONV_FAILED;
 #endif
 }
 


### PR DESCRIPTION
Hi,

We got this in OpenBSD ports tree since forever http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/mail/libetpan/patches/patch-src_low-level_feed_parser_c

Cheers,
Daniel