### PR TITLE
fix 64 bits time_t issues

### DIFF
--- a/src/driver/implementation/mh/mhdriver_cached_message.c
+++ b/src/driver/implementation/mh/mhdriver_cached_message.c
@@ -187,8 +187,8 @@ static int mh_initialize(mailmessage * msg_info)
   
   mh_msg_info = data.data;
 
-  snprintf(static_uid, PATH_MAX, "%u-%lu-%lu", msg_info->msg_index,
-	   mh_msg_info->msg_mtime, (unsigned long) mh_msg_info->msg_size);
+  snprintf(static_uid, PATH_MAX, "%u-%lld-%zu", msg_info->msg_index,
+           (long long)mh_msg_info->msg_mtime, mh_msg_info->msg_size);
   uid = strdup(static_uid);
   if (uid == NULL)
     return MAIL_ERROR_MEMORY;

--- a/src/low-level/mime/mailmime_types_helper.c
+++ b/src/low-level/mime/mailmime_types_helper.c
@@ -518,7 +518,7 @@ char * mailmime_generate_boundary(void)
   value = random();
 
   gethostname(name, MAX_MESSAGE_ID);
-  snprintf(id, MAX_MESSAGE_ID, "%lx_%lx_%x", now, value, getpid());
+  snprintf(id, MAX_MESSAGE_ID, "%llx_%lx_%x", (long long)now, value, getpid());
 
   return strdup(id);
 }

--- a/tests/mime-create.c
+++ b/tests/mime-create.c
@@ -272,7 +272,7 @@ static char * generate_boundary(const char * boundary_prefix)
     if (boundary_prefix == NULL)
         boundary_prefix = "";
     
-    snprintf(id, MAX_MESSAGE_ID, "%s%lx_%lx_%x", boundary_prefix, now, value, getpid());
+    snprintf(id, MAX_MESSAGE_ID, "%s%llx_%lx_%x", boundary_prefix, (long long)now, value, getpid());
     
     return strdup(id);
 }


### PR DESCRIPTION
Hi,
The last patches we have in the OpenBSD ports tree. Those are because our time_t is 64bits.
Thanks!