### PR TITLE
fix header/source inconsistency

### DIFF
--- a/src/data-types/chash.c
+++ b/src/data-types/chash.c
@@ -393,12 +393,12 @@ int chash_resize(chash * hash, unsigned int size)
 
 #ifdef NO_MACROS
 LIBETPAN_EXPORT
-int chash_count(chash * hash) {
+unsigned int chash_count(chash * hash) {
   return hash->count;
 }
 
 LIBETPAN_EXPORT
-int chash_size(chash * hash) {
+unsigned int chash_size(chash * hash) {
   return hash->size;
 }
 


### PR DESCRIPTION
When using the NO_MACRO preprocessor I discovered an inconsistency between header and source file. I fixed the source file to match the header.