### PR TITLE
Gmail xgmraw literalplus support (i18n search)

### DIFF
--- a/src/low-level/imap/mailimap_sender.c
+++ b/src/low-level/imap/mailimap_sender.c
@@ -2654,7 +2654,7 @@ static int search_key_send(mailstream * fd,
       r = mailimap_space_send(fd);
       if (r != MAILIMAP_NO_ERROR)
         return r;
-      r = mailimap_quoted_send(fd, key->sk_data.sk_xgmraw);
+      r = mailimap_astring_literalplus_send(fd, key->sk_data.sk_xgmraw, literalplus_enabled);
       if (r != MAILIMAP_NO_ERROR)
         return r;
       return MAILIMAP_NO_ERROR;


### PR DESCRIPTION
Enable non-latin XGMRAW search in gmail.