### PR TITLE
first version of lmtp feature

### DIFF
--- a/src/data-types/connect.c
+++ b/src/data-types/connect.c
@@ -183,6 +183,34 @@ int mail_tcp_connect_with_local_address(const char * server, uint16_t port,
 	return mail_tcp_connect_with_local_address_timeout(server, port, local_address, local_port, 0);
 }
 
+#ifndef WIN32
+#include <sys/un.h>
+int mail_unix_connect_socket(const char *path)
+{
+ struct sockaddr_un sa;
+ int s;
+
+ if (!(memcpy(sa.sun_path, path, strlen(path)))) {
+    return -1;
+ }
+ sa.sun_family = AF_UNIX;
+
+
+ if (0 > (s = socket(AF_UNIX, SOCK_STREAM, 0)))
+    return -1;
+
+ if (prepare_fd(s))
+    goto close_socket;
+ if (connect(s, (struct sockaddr *) &sa, sizeof(struct sockaddr_un)))
+    goto close_socket;
+ return s;
+
+close_socket:
+ close(s);
+ return -1;
+}
+#endif
+
 int mail_tcp_connect_with_local_address_timeout(const char * server, uint16_t port,
     const char * local_address, uint16_t local_port, time_t timeout)
 {
@@ -200,6 +228,9 @@ int mail_tcp_connect_with_local_address_timeout(const char * server, uint16_t po
 #else
   int s;
   int r;
+
+  if ('/' == server[0])
+    return mail_unix_connect_socket(server);
 #endif
 
 #ifndef HAVE_IPV6

--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -483,10 +483,10 @@ int mailsmtp_status(int smtpstatus)
  * if retcodes is not NULL, the individual rcpt-stati are stored there
  *  */
 int maillmtp_data_message(mailsmtp * session,
-			   const char * message,
-			   size_t size,
-               clist * recipient_list,
-               clist * retcodes)
+                          const char * message,
+                          size_t size,
+                          clist * recipient_list,
+                          int * retcodes)
 {
   int r, ret = MAILSMTP_NO_ERROR;
   unsigned int i = 0;
@@ -500,9 +500,9 @@ int maillmtp_data_message(mailsmtp * session,
   for (iter = clist_begin(recipient_list); iter; iter = clist_next(iter)) {
     r = read_response(session);
     if (MAILSMTP_NO_ERROR != mailsmtp_status(r))
-        ret = mailsmtp_status(r);
+      ret = mailsmtp_status(r);
     if (retcodes)
-        clist_append(retcodes, r);
+      retcodes[i++] = r;
   }
   return ret;
 }

--- a/src/low-level/smtp/mailsmtp.h
+++ b/src/low-level/smtp/mailsmtp.h
@@ -107,10 +107,10 @@ int mailsmtp_data_message(mailsmtp * session,
 
 LIBETPAN_EXPORT
 int maillmtp_data_message(mailsmtp * session,
-            const char * message,
-            size_t size,
-            clist * recipient_list,
-            clist * retcodes);
+                          const char * message,
+                          size_t size,
+                          clist * recipient_list,
+                          int * retcodes);
 
 LIBETPAN_EXPORT
 int mailsmtp_data_message_quit(mailsmtp * session,

--- a/src/low-level/smtp/mailsmtp.h
+++ b/src/low-level/smtp/mailsmtp.h
@@ -107,10 +107,10 @@ int mailsmtp_data_message(mailsmtp * session,
 
 LIBETPAN_EXPORT
 int maillmtp_data_message(mailsmtp * session,
-               carray *ret,
-			   const char * message,
-			   size_t size);
-
+            const char * message,
+            size_t size,
+            clist * recipient_list,
+            clist * retcodes);
 
 LIBETPAN_EXPORT
 int mailsmtp_data_message_quit(mailsmtp * session,

--- a/src/low-level/smtp/mailsmtp.h
+++ b/src/low-level/smtp/mailsmtp.h
@@ -106,6 +106,13 @@ int mailsmtp_data_message(mailsmtp * session,
 			   size_t size);
 
 LIBETPAN_EXPORT
+int maillmtp_data_message(mailsmtp * session,
+               carray *ret,
+			   const char * message,
+			   size_t size);
+
+
+LIBETPAN_EXPORT
 int mailsmtp_data_message_quit(mailsmtp * session,
                                const char * message,
                                size_t size);
@@ -114,6 +121,9 @@ LIBETPAN_EXPORT
 int mailsmtp_data_message_quit_no_disconnect(mailsmtp * session,
                                              const char * message,
                                              size_t size);
+
+LIBETPAN_EXPORT
+int mailesmtp_lhlo(mailsmtp * session, const char *hostname);
 
 LIBETPAN_EXPORT
 int mailesmtp_ehlo(mailsmtp * session);

--- a/tests/smtpsend.c
+++ b/tests/smtpsend.c
@@ -245,7 +245,7 @@ int send_message(char *data, size_t len, char**rcpts) {
     goto error;
   }
   if (smtp_lmtp){
-      retcodes = malloc((clist_count(recipients) * sizeof(int)) + 1);
+      retcodes = malloc((clist_count(recipients) * sizeof(int)));
     if ((ret = maillmtp_data_message(smtp, data, len, recipients, retcodes)) != MAILSMTP_NO_ERROR) {
         fprintf(stderr, "maillmtp_data: %s (%d)\n", mailsmtp_strerror(ret), ret);
         goto error;

--- a/tests/smtpsend.c
+++ b/tests/smtpsend.c
@@ -150,7 +150,7 @@ int send_message(char *data, size_t len, char**rcpts) {
   char **r;
   int esmtp = 0;
   mailsmtp *smtp = NULL;
-  clist *retcodes = NULL;
+  int *retcodes = NULL;
   clist *recipients = clist_new();
 
   if ((smtp = mailsmtp_new(0, NULL)) == NULL) {
@@ -245,13 +245,13 @@ int send_message(char *data, size_t len, char**rcpts) {
     goto error;
   }
   if (smtp_lmtp){
-      retcodes = clist_new();
+      retcodes = malloc((clist_count(recipients) * sizeof(int)) + 1);
     if ((ret = maillmtp_data_message(smtp, data, len, recipients, retcodes)) != MAILSMTP_NO_ERROR) {
         fprintf(stderr, "maillmtp_data: %s (%d)\n", mailsmtp_strerror(ret), ret);
         goto error;
     }
-    for (i = 0; i < clist_count(retcodes); i++)
-      fprintf(stderr, "recipient %s returned: %d\n", clist_nth_data(recipients, i), clist_nth_data(retcodes, i));
+    for (i = 0; i < clist_count(recipients); i++)
+      fprintf(stderr, "recipient %s returned: %d\n", (char *)clist_nth_data(recipients, i), retcodes[i]);
   } else if ((ret = mailsmtp_data_message(smtp, data, len)) != MAILSMTP_NO_ERROR) {
         fprintf(stderr, "mailsmtp_data_message: %s\n", mailsmtp_strerror(ret));
         goto error;
@@ -262,8 +262,7 @@ int send_message(char *data, size_t len, char**rcpts) {
  error:
   if (smtp != NULL)
     mailsmtp_free(smtp);
-  if (retcodes != NULL)
-      clist_free(retcodes);
+  free(retcodes);
   clist_free(recipients);
   if (s >= 0)
     close(s);


### PR DESCRIPTION
Hi,

I am trying to add lmtp to libetpan.
As far as I can see the only differences to smtp is the LHLO command and the differences in data response, if delivering to several recipients.

I dont really like my solution in getting the codes of data_message() maybe you have a better idea to solve this?

at the moment you have to set the array size to the number of accepted recipients from the smtp_recip() commands to not end up hanging on a select()

I also added an example included in tests/smtpsend.c to show how it works at the moment.

Greetz


