### PR TITLE
Add empty element at end for getopt_long options

### DIFF
--- a/tests/option-parser.c
+++ b/tests/option-parser.c
@@ -97,6 +97,7 @@ int parse_options(int argc, char ** argv,
     {"cache",    1, 0, 'c'},
     {"flags",    1, 0, 'f'},
 	{"debug-stream", 0, 0, 'D'},
+    {NULL,       0, 0, 0},
   };
 #endif
   int r;

--- a/tests/smtpsend.c
+++ b/tests/smtpsend.c
@@ -286,6 +286,7 @@ int main(int argc, char **argv) {
     {"no-esmtp", 0, 0, 'E'},
     {"ssl",      0, 0, 'L'},
     {"lmtp",     0, 0, 'T'},
+    {NULL,       0, 0, 0},
   };
 #endif
 


### PR DESCRIPTION
`getopt_long` requires a trailing element with null/zero elements at the end, otherwise it will crash (since it cannot know where the array ends).