### PR TITLE
lmtp on local socket: fix socketpath checks

### DIFF
--- a/src/data-types/connect.c
+++ b/src/data-types/connect.c
@@ -190,7 +190,11 @@ int mail_unix_connect_socket(const char *path)
  struct sockaddr_un sa;
  int s;
 
- if (!(memcpy(sa.sun_path, path, strlen(path)))) {
+ if (sizeof(sa.sun_path) <= strlen(path)) {
+    return -1;
+ }
+
+ if (!(memcpy(sa.sun_path, path, sizeof(sa.sun_path)))) {
     return -1;
  }
  sa.sun_family = AF_UNIX;


### PR DESCRIPTION
check path boundaries and ensure terminating zero