### PR TITLE
Fixed memoery leak in mailimap_acl_myrights

### DIFF
--- a/src/low-level/imap/acl.c
+++ b/src/low-level/imap/acl.c
@@ -345,8 +345,10 @@ int mailimap_acl_myrights(mailimap * session,
         ext_data->ext_extension->ext_id == MAILIMAP_EXTENSION_ACL &&
         ext_data->ext_type == MAILIMAP_ACL_TYPE_MYRIGHTS_DATA) {
           * result = (struct mailimap_acl_myrights_data *)ext_data->ext_data;
+          ext_data->ext_data = NULL;
           /* remove the element from rsp_extension_list */
           clist_delete(session->imap_response_info->rsp_extension_list, cur);
+          mailimap_extension_data_free(ext_data);
 
           break;
       }

--- a/src/low-level/imap/mailimap_extension.c
+++ b/src/low-level/imap/mailimap_extension.c
@@ -166,7 +166,8 @@ mailimap_extension_data_free(struct
   if (data == NULL)
     return;
 
-  if (data->ext_extension != NULL)
+  if (data->ext_extension != NULL && data->ext_data != NULL)
+    /* ext_free() includes free(data) */
     data->ext_extension->ext_free(data);
   else
     free(data);


### PR DESCRIPTION
valgrind log:

> ==8823== at 0x4C28BF5: malloc (vg_replace_malloc.c:299)
> ==8823== by 0x5153975: mailimap_extension_data_new
> ==8823== by 0x514CD7C: mailimap_acl_parse
> ==8823== by 0x5153833: mailimap_extension_data_parse
> ==8823== by 0x515A44F: mailimap_response_data_parse_progress
> ==8823== by 0x515B274: mailimap_cont_req_or_resp_data_parse_progress
> ==8823== by 0x515B4B2: mailimap_response_parse_progress
> ==8823== by 0x515B8C2: mailimap_response_parse_with_context
> ==8823== by 0x515176B: mailimap_parse_response
> ==8823== by 0x514C67B: mailimap_acl_myrights