### PR TITLE
changes for OpenSSL 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -212,7 +212,7 @@ if test "x$with_openssl" != "xno"; then
   AC_CHECK_HEADER(openssl/ssl.h, [
    AC_CHECK_LIB(rsaref, main, [SSLLIBS="-lrsaref"])
    AC_CHECK_LIB(crypto, main, [SSLLIBS="-lcrypto $SSLLIBS"], [], [$SSLLIBS])
-   AC_CHECK_LIB(ssl, SSL_library_init, with_openssl=yes, [], [$SSLLIBS])])
+   AC_CHECK_LIB(ssl, SSL_CTX_new, with_openssl=yes, [], [$SSLLIBS])])
   if test "x$with_openssl" != "xyes"; then
     CPPFLAGS="$OCPPFLAGS"
     LDFLAGS="$OLDFLAGS"

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -408,7 +408,7 @@ static void mailstream_ssl_context_free(struct mailstream_ssl_context * ssl_ctx)
 
 static int mailstream_openssl_client_cert_cb(SSL *ssl, X509 **x509, EVP_PKEY **pkey)
 {
-	struct mailstream_ssl_context * ssl_context = (struct mailstream_ssl_context *)SSL_CTX_get_app_data(ssl->ctx);
+	struct mailstream_ssl_context * ssl_context = (struct mailstream_ssl_context *)SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl));
 	
 	if (x509 == NULL || pkey == NULL) {
 		return 0;


### PR DESCRIPTION
- the function SSL_library_init does not exist any more - use SSL_CTX_new
  for the detection of OpenSSL in the configure script
- do not access the SSL structure directly - use the function
  SSL_get_SSL_CTX to access the SSL_CTX