### PR TITLE
remove SP and \t in is_atext

### DIFF
--- a/src/low-level/imf/mailimf_write_generic.c
+++ b/src/low-level/imf/mailimf_write_generic.c
@@ -1449,8 +1449,6 @@ static int is_atext(const char * s)
     if (isdigit((unsigned char) * p))
       continue;
     switch (*p) {
-    case ' ':
-    case '\t':
     case '!':
     case '#':
     case '$':


### PR DESCRIPTION
According to   https://tools.ietf.org/html/rfc2822#section-3.2.4
The "space" and "\t" not belong to atext.
So "space" and "\t" are removed from the function "is_atext".