### PR TITLE
Fix NULL pointer dereference in  mailimap_flag_list_free().

### DIFF
--- a/src/low-level/imap/mailimap_types.c
+++ b/src/low-level/imap/mailimap_types.c
@@ -1201,8 +1201,10 @@ mailimap_flag_list_new(clist * fl_list)
 LIBETPAN_EXPORT
 void mailimap_flag_list_free(struct mailimap_flag_list * flag_list)
 {
-  clist_foreach(flag_list->fl_list, (clist_func) mailimap_flag_free, NULL);
-  clist_free(flag_list->fl_list);
+  if (flag_list->fl_list) {
+    clist_foreach(flag_list->fl_list, (clist_func) mailimap_flag_free, NULL);
+    clist_free(flag_list->fl_list);
+  }
   free(flag_list);
 }
 


### PR DESCRIPTION
This fixes libetpan crash when it talks to ProtonMail Bridge IMAP interface. See http://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=4016 for more background.