### PR TITLE
check for NULL pointers possibly returned by mailprivacy_new_file_part()

### DIFF
--- a/src/engine/mailprivacy_gnupg.c
+++ b/src/engine/mailprivacy_gnupg.c
@@ -1491,6 +1491,10 @@ static int pgp_sign_mime(struct mailprivacy * privacy,
   
   multipart = mailprivacy_new_file_part(privacy, NULL,
       "multipart/signed", -1);
+  if (multipart == NULL) {
+    res = MAIL_ERROR_MEMORY;
+    goto unlink_description;
+  }
   
   content = multipart->mm_content_type;
   
@@ -1871,6 +1875,10 @@ static int pgp_sign_encrypt_mime(struct mailprivacy * privacy,
   
   multipart = mailprivacy_new_file_part(privacy, NULL,
       "multipart/encrypted", -1);
+  if (multipart==NULL) {
+    res = MAIL_ERROR_MEMORY;
+    goto unlink_description;
+  }
   
   content = multipart->mm_content_type;
   
@@ -1915,10 +1923,10 @@ static int pgp_sign_encrypt_mime(struct mailprivacy * privacy,
       version_filename,
       "application/pgp-encrypted",
       MAILMIME_MECHANISM_8BIT);
-  if (r != MAIL_NO_ERROR) {
+  if (version_mime==NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
-    res = r;
+    res = MAIL_ERROR_MEMORY;
     goto unlink_version;
   }
 
@@ -1938,10 +1946,10 @@ static int pgp_sign_encrypt_mime(struct mailprivacy * privacy,
       encrypted_filename,
       "application/octet-stream",
       MAILMIME_MECHANISM_8BIT);
-  if (r != MAIL_NO_ERROR) {
+  if (encrypted_mime==NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
-    res = r;
+    res = MAIL_ERROR_MEMORY;
     goto unlink_version;
   }
   
@@ -2092,6 +2100,10 @@ static int pgp_encrypt_mime(struct mailprivacy * privacy,
   
   multipart = mailprivacy_new_file_part(privacy, NULL,
       "multipart/encrypted", -1);
+  if (multipart == NULL) {
+    res = MAIL_ERROR_MEMORY;
+    goto unlink_description;
+  }
   
   content = multipart->mm_content_type;
   
@@ -2135,10 +2147,10 @@ static int pgp_encrypt_mime(struct mailprivacy * privacy,
       version_filename,
       "application/pgp-encrypted",
       MAILMIME_MECHANISM_8BIT);
-  if (r != MAIL_NO_ERROR) {
+  if (version_mime==NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
-    res = r;
+    res = MAIL_ERROR_MEMORY;
     goto unlink_version;
   }
 
@@ -2158,10 +2170,10 @@ static int pgp_encrypt_mime(struct mailprivacy * privacy,
       encrypted_filename,
       "application/octet-stream",
       MAILMIME_MECHANISM_8BIT);
-  if (r != MAIL_NO_ERROR) {
+  if (encrypted_mime==NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
-    res = r;
+    res = MAIL_ERROR_MEMORY;
     goto unlink_version;
   }
   

--- a/src/engine/mailprivacy_gnupg.c
+++ b/src/engine/mailprivacy_gnupg.c
@@ -1875,7 +1875,7 @@ static int pgp_sign_encrypt_mime(struct mailprivacy * privacy,
   
   multipart = mailprivacy_new_file_part(privacy, NULL,
       "multipart/encrypted", -1);
-  if (multipart==NULL) {
+  if (multipart == NULL) {
     res = MAIL_ERROR_MEMORY;
     goto unlink_description;
   }
@@ -1923,7 +1923,7 @@ static int pgp_sign_encrypt_mime(struct mailprivacy * privacy,
       version_filename,
       "application/pgp-encrypted",
       MAILMIME_MECHANISM_8BIT);
-  if (version_mime==NULL) {
+  if (version_mime == NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
     res = MAIL_ERROR_MEMORY;
@@ -1946,7 +1946,7 @@ static int pgp_sign_encrypt_mime(struct mailprivacy * privacy,
       encrypted_filename,
       "application/octet-stream",
       MAILMIME_MECHANISM_8BIT);
-  if (encrypted_mime==NULL) {
+  if (encrypted_mime == NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
     res = MAIL_ERROR_MEMORY;
@@ -2147,7 +2147,7 @@ static int pgp_encrypt_mime(struct mailprivacy * privacy,
       version_filename,
       "application/pgp-encrypted",
       MAILMIME_MECHANISM_8BIT);
-  if (version_mime==NULL) {
+  if (version_mime == NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
     res = MAIL_ERROR_MEMORY;
@@ -2170,7 +2170,7 @@ static int pgp_encrypt_mime(struct mailprivacy * privacy,
       encrypted_filename,
       "application/octet-stream",
       MAILMIME_MECHANISM_8BIT);
-  if (encrypted_mime==NULL) {
+  if (encrypted_mime == NULL) {
     mailprivacy_mime_clear(multipart);
     mailmime_free(multipart);
     res = MAIL_ERROR_MEMORY;


### PR DESCRIPTION
the return value was sometimes not checked or a check against `r` instead of the returned pointer was done.

@dinhviethoa thanks for the lib btw - we use it in Delta Chat :)