### PR TITLE
add missing mutex-initialisation in mailstream_openssl_init_not_required()

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -262,6 +262,7 @@ void mailstream_gnutls_init_not_required(void)
 void mailstream_openssl_init_not_required(void)
 {
 #ifdef USE_SSL
+  mailstream_ssl_init_lock();
   MUTEX_LOCK(&ssl_lock);
   openssl_init_done = 1;
   MUTEX_UNLOCK(&ssl_lock);


### PR DESCRIPTION
if i understand mailstream_openssl_init_not_required() correctly, the function should be called when OpenSSL is also needed for other purposes in an app and the app needs to initialize OpenSSL on its own (because it needs eg. OpenSSL before any call to libetpan is done).

this would require to call mailstream_openssl_init_not_required() unconditionally before any calls to other libetpan functions.

however, when calling mailstream_openssl_init_not_required() when using WIN32, the MUTEX_LOCK macro will expand to EnterCriticalSection() on an uninitialized ssl_lock.
this can be fixed by calling mailstream_ssl_init_lock() (as also done when processing the normal initialization).

btw: when PTHREAD is used instead of WIN32, this problem does not occur as ssl_lock is initialized as a static variable.