### PR TITLE
avoid several compiler warnings

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -428,7 +428,7 @@ static int mailstream_openssl_client_cert_cb(SSL *ssl, X509 **x509, EVP_PKEY **p
 }
 
 static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
-	SSL_METHOD * method, void (* callback)(struct mailstream_ssl_context * ssl_context, void * cb_data),
+	const SSL_METHOD * method, void (* callback)(struct mailstream_ssl_context * ssl_context, void * cb_data),
 	void * cb_data)
 {
   struct mailstream_ssl_data * ssl_data;

--- a/src/low-level/imap/mailimap_extension_types.h
+++ b/src/low-level/imap/mailimap_extension_types.h
@@ -33,6 +33,7 @@
 #define MAILIMAP_EXTENSION_TYPES_H
 
 #include <libetpan/mailstream.h>
+#include <libetpan/mailimap_types.h>
 
 struct mailimap_extension_data;
 


### PR DESCRIPTION
together with the fixes of the last weeks, at least gcc 5.4.0 does not show any more warnings :)