### PR TITLE
Add error string for MAILSMTP_ERROR_AUTH_NOT_SUPPORTED

### DIFF
--- a/src/low-level/smtp/mailsmtp.c
+++ b/src/low-level/smtp/mailsmtp.c
@@ -1224,6 +1224,8 @@ const char * mailsmtp_strerror(int errnum)
     return "Transaction failed";
   case MAILSMTP_ERROR_MEMORY:
     return "Memory error";
+  case MAILSMTP_ERROR_AUTH_NOT_SUPPORTED;
+    return "Authentication is not supported";
   case MAILSMTP_ERROR_CONNECTION_REFUSED:
     return "Connection refused";
   case MAILSMTP_ERROR_STARTTLS_TEMPORARY_FAILURE:
@@ -1231,7 +1233,7 @@ const char * mailsmtp_strerror(int errnum)
   case MAILSMTP_ERROR_STARTTLS_NOT_SUPPORTED:
     return "TLS not supported by server";
   case MAILSMTP_ERROR_AUTH_LOGIN:
-  	return "Login failed";
+    return "Login failed";
   default:
     return "Unknown error code";
   }


### PR DESCRIPTION
I was playing around with [Greenmail](http://www.icegreen.com/greenmail/) and got an `Unknown error code` when trying to authenticate with the smtp server. This provides a better explanation.