### PR TITLE
Tls server name indication support

### DIFF
--- a/doc/API.sgml
+++ b/doc/API.sgml
@@ -1213,6 +1213,22 @@ mailstream * mailstream_ssl_open(int fd);
           <command>mailstream_ssl_open()</command> will open a
           TLS/SSL socket.
         </para>
+
+        <programlisting role="C">
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    char * hostname)
+        </programlisting>
+
+        <para>
+          <command>mailstream_ssl_set_server_name()</command> allows the client
+          to enable the use of the Server Name Indication TLS extension upon
+          opening a TLS stream, by providing the domain name to be indicated
+          to server as the desired destination. <command>ssl_context</command>
+          is the context pointer passed to the client-supplied callback
+          function by <command>mailstream_ssl_open_with_callback()</command>
+          etc. Note that <command>hostname</command> must be a domain name, not
+          a string representation of an IP address.
+        </para>
       </sect2>  
     </sect1>
 

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -1361,6 +1361,27 @@ int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_cont
 #endif /* USE_SSL */
 }
 
+LIBETPAN_EXPORT
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    char * hostname)
+{
+  int r = -1;
+
+#ifdef USE_SSL
+# ifdef USE_GNUTLS
+  r = gnutls_server_name_set(ssl_context->session, GNUTLS_NAME_DNS, hostname, strlen(hostname));
+# else /* !USE_GNUTLS */
+#  if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
+  if (SSL_set_tlsext_host_name(ssl_context->openssl_ssl_ctx, hostname)) {
+    r = 0;
+  }
+#  endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
+# endif /* !USE_GNUTLS */
+#endif /* USE_SSL */
+
+  return r;
+}
+
 #ifdef USE_SSL
 #ifndef USE_GNUTLS
 static struct mailstream_ssl_context * mailstream_ssl_context_new(SSL_CTX * open_ssl_ctx, int fd)

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -1376,7 +1376,12 @@ int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
 
 #ifdef USE_SSL
 # ifdef USE_GNUTLS
-  r = gnutls_server_name_set(ssl_context->session, GNUTLS_NAME_DNS, hostname, strlen(hostname));
+  if (hostname != NULL) {
+    r = gnutls_server_name_set(ssl_context->session, GNUTLS_NAME_DNS, hostname, strlen(hostname));
+  }
+  else {
+    r = gnutls_server_name_set(ssl_context->session, GNUTLS_NAME_DNS, "", 0U);
+  }
 # else /* !USE_GNUTLS */
 #  if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
   if (hostname != NULL) {

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -1388,7 +1388,10 @@ int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
     ssl_context->server_name = strdup(hostname);
   }
   else {
-    ssl_context->server_name[0] = '\0';
+    if (ssl_context->server_name != NULL) {
+      free(ssl_context->server_name);
+    }
+    ssl_context->server_name = NULL;
   }
   r = 0;
 #  endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -1385,6 +1385,14 @@ int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
 # else /* !USE_GNUTLS */
 #  if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
   if (hostname != NULL) {
+    /* Unfortunately we can't set this in the openssl session yet since it
+     * hasn't been created yet; we only have the openssl context at this point.
+     * We will set it in the openssl session when we create it, soon after the
+     * client callback that we expect to be calling us (since it is the way the
+     * client gets our mailstream_ssl_context) returns (see
+     * ssl_data_new_full()) but we cannot rely on the client persisting it. We
+     * must therefore take a temporary copy here, which we free once we've set
+     * it in the openssl session. */
     ssl_context->server_name = strdup(hostname);
   }
   else {

--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -113,7 +113,9 @@ struct mailstream_ssl_context
   SSL_CTX * openssl_ssl_ctx;
   X509* client_x509;
   EVP_PKEY *client_pkey;
+# if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
   char * server_name;
+# endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
 #else
   gnutls_session session;
   gnutls_x509_crt client_x509;
@@ -465,11 +467,13 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
   if (ssl_conn == NULL)
     goto free_ctx;
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
   if (ssl_context->server_name != NULL) {
     SSL_set_tlsext_host_name(ssl_conn, ssl_context->server_name);
     free(ssl_context->server_name);
     ssl_context->server_name = NULL;
   }
+#endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
 
   if (SSL_set_fd(ssl_conn, fd) == 0)
     goto free_ssl_conn;
@@ -1422,7 +1426,9 @@ static struct mailstream_ssl_context * mailstream_ssl_context_new(SSL_CTX * open
   ssl_ctx->openssl_ssl_ctx = open_ssl_ctx;
   ssl_ctx->client_x509 = NULL;
   ssl_ctx->client_pkey = NULL;
+#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
   ssl_ctx->server_name = NULL;
+#endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
   ssl_ctx->fd = fd;
   
   return ssl_ctx;
@@ -1431,9 +1437,11 @@ static struct mailstream_ssl_context * mailstream_ssl_context_new(SSL_CTX * open
 static void mailstream_ssl_context_free(struct mailstream_ssl_context * ssl_ctx)
 {
   if (ssl_ctx != NULL) {
+#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
     if (ssl_ctx->server_name != NULL) {
       free(ssl_ctx->server_name);
     }
+#endif /* (OPENSSL_VERSION_NUMBER >= 0x10000000L) */
     free(ssl_ctx);
   }
 }

--- a/src/data-types/mailstream_ssl.h
+++ b/src/data-types/mailstream_ssl.h
@@ -124,6 +124,10 @@ int mailstream_ssl_set_server_certicate(struct mailstream_ssl_context * ssl_cont
     char * CAfile, char * CApath);
 
 LIBETPAN_EXPORT
+int mailstream_ssl_set_server_name(struct mailstream_ssl_context * ssl_context,
+    char * hostname);
+
+LIBETPAN_EXPORT
 void * mailstream_ssl_get_openssl_ssl_ctx(struct mailstream_ssl_context * ssl_context);
 
 LIBETPAN_EXPORT


### PR DESCRIPTION
Candidate extension as per my earlier comment on #258 

Seen to work against both gnutls and openssl on linux with a patched Claws Mail connecting to a dovecot IMAP server. I don't have anything else available to test it against unfortunately.