### PR TITLE
Fix build with curl 7.62.0

### DIFF
--- a/src/low-level/feed/newsfeed.c
+++ b/src/low-level/feed/newsfeed.c
@@ -535,7 +535,9 @@ static int curl_error_convert(int curl_res)
   case CURLE_SSL_ENGINE_SETFAILED:
   case CURLE_SSL_CERTPROBLEM:
   case CURLE_SSL_CIPHER:
+#if LIBCURL_VERSION_NUM < 0x073e00
   case CURLE_SSL_CACERT:
+#endif
   case CURLE_FTP_SSL_FAILED:
   case CURLE_SSL_ENGINE_INITFAILED:
     return NEWSFEED_ERROR_SSL;


### PR DESCRIPTION
from CHANGES:
ssl: deprecate CURLE_SSL_CACERT in favour of a unified error code
Long live CURLE_PEER_FAILED_VERIFICATION