### PR TITLE
Support BoringSSL as well as OpenSSL

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -440,7 +440,7 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
   SSL_CTX * tmp_ctx;
   struct mailstream_cancel * cancel;
   struct mailstream_ssl_context * ssl_context = NULL;
-#ifdef SSL_MODE_RELEASE_BUFFERS
+#if SSL_MODE_RELEASE_BUFFERS
   long mode = 0;
 #endif
   
@@ -459,7 +459,7 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
   SSL_CTX_set_client_cert_cb(tmp_ctx, mailstream_openssl_client_cert_cb);
   ssl_conn = (SSL *) SSL_new(tmp_ctx);
   
-#ifdef SSL_MODE_RELEASE_BUFFERS
+#if SSL_MODE_RELEASE_BUFFERS
   mode = SSL_get_mode(ssl_conn);
   SSL_set_mode(ssl_conn, mode | SSL_MODE_RELEASE_BUFFERS);
 #endif


### PR DESCRIPTION
In BoringSSL this is defined as 0 in order to disable this.  In
OpenSSL this is a non-zero value.  So a simple #if check supports both
of these.