### PR TITLE
Corrected segfault in TLS SNI code with OpenSSL in the case that call…

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -468,7 +468,7 @@ static struct mailstream_ssl_data * ssl_data_new_full(int fd, time_t timeout,
     goto free_ctx;
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
-  if (ssl_context->server_name != NULL) {
+  if (ssl_context != NULL && ssl_context->server_name != NULL) {
     SSL_set_tlsext_host_name(ssl_conn, ssl_context->server_name);
     free(ssl_context->server_name);
     ssl_context->server_name = NULL;


### PR DESCRIPTION
…backs are not used.

Fix for #314. In the case that a callback is not used, no context is created and of course no hostname can be set within it for SNI... So we should just skip trying to make the relevant OpenSSL call in that case, rather than dereferencing NULL in an attempt to find out whether the callback set a hostname! Sorry...