### PR TITLE
add missing stddef.h include for 'NULL'

### DIFF
--- a/src/low-level/imap/clientid.c
+++ b/src/low-level/imap/clientid.c
@@ -33,6 +33,8 @@
 #	include <config.h>
 #endif
 
+#include <stdlib.h>
+
 #include "mailimap_sender.h"
 #include "clientid_sender.h"
 #include "clientid.h"


### PR DESCRIPTION
clientid.c: In function 'mailimap_clientid':
clientid.c:66:38: error: 'NULL' undeclared (first use in this function)
   if (mailimap_read_line(session) == NULL)
                                      ^~~~
clientid.c:66:38: note: 'NULL' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
clientid.c:39:1:
+#include <stddef.h>

clientid.c:66:38:
   if (mailimap_read_line(session) == NULL)





Fixes build on Void Linux musl archs