### PR TITLE
Fix the compiler warning against uninitialized use

### DIFF
--- a/src/low-level/imap/mailimap_parser.c
+++ b/src/low-level/imap/mailimap_parser.c
@@ -4860,6 +4860,7 @@ static int mailimap_envelope_parse_workaround_qq_mail(mailstream * fd, MMAPStrin
   message_id = NULL;
   first_string = NULL;
   second_string = NULL;
+  res = MAILIMAP_ERROR_PARSE;
 
   cur_token = * indx;
 

--- a/src/low-level/mime/mailmime_decode.c
+++ b/src/low-level/mime/mailmime_decode.c
@@ -407,6 +407,7 @@ int mailmime_encoded_word_parse(const char * message, size_t length,
 
   cur_token = * indx;
 
+  text = NULL;
   lookfwd_charset = NULL;
   missing_closing_quote = 0;
   has_fwd = 0;


### PR DESCRIPTION
Some local variables may be accessed with uninitialized values and hence cause serious issues. Fix it. Compiler warnings attached below:

> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:600:11: warning: variable 'text' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>       if (r != MAILIMF_NO_ERROR) {
>           ^~~~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:650:30: note: uninitialized use occurs here
>   mailmime_encoded_text_free(text);
>                              ^~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:600:7: note: remove the 'if' if its condition is always false
>       if (r != MAILIMF_NO_ERROR) {
>       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:590:11: warning: variable 'text' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>       if (r != MAILIMF_NO_ERROR) {
>           ^~~~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:650:30: note: uninitialized use occurs here
>   mailmime_encoded_text_free(text);
>                              ^~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:590:7: note: remove the 'if' if its condition is always false
>       if (r != MAILIMF_NO_ERROR) {
>       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:575:9: warning: variable 'text' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>     if (body == NULL) {
>         ^~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:650:30: note: uninitialized use occurs here
>   mailmime_encoded_text_free(text);
>                              ^~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:575:5: note: remove the 'if' if its condition is always false
>     if (body == NULL) {
>     ^~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:502:11: warning: variable 'text' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>       if (body == NULL) {
>           ^~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:650:30: note: uninitialized use occurs here
>   mailmime_encoded_text_free(text);
>                              ^~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:502:7: note: remove the 'if' if its condition is always false
>       if (body == NULL) {
>       ^~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/mime/mailmime_decode.c:391:14: note: initialize the variable 'text' to silence this warning
>   char * text;
>              ^
>               = NULL
> 4 warnings generated.
> 
> 
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4928:9: warning: variable 'res' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>     if (from == NULL) {
>         ^~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:5030:10: note: uninitialized use occurs here
>   return res;
>          ^~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4928:5: note: remove the 'if' if its condition is always false
>     if (from == NULL) {
>     ^~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4921:9: warning: variable 'res' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>     if (r < 0) {
>         ^~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:5030:10: note: uninitialized use occurs here
>   return res;
>          ^~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4921:5: note: remove the 'if' if its condition is always false
>     if (r < 0) {
>     ^~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4915:9: warning: variable 'res' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>     if (list == NULL) {
>         ^~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:5030:10: note: uninitialized use occurs here
>   return res;
>          ^~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4915:5: note: remove the 'if' if its condition is always false
>     if (list == NULL) {
>     ^~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4910:9: warning: variable 'res' is used uninitialized whenever 'if' condition is true
>       [-Wsometimes-uninitialized]
>     if (addr == NULL) {
>         ^~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:5030:10: note: uninitialized use occurs here
>   return res;
>          ^~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4910:5: note: remove the 'if' if its condition is always false
>     if (addr == NULL) {
>     ^~~~~~~~~~~~~~~~~~~
> build-android/jni/../.././src/low-level/imap/mailimap_parser.c:4850:10: note: initialize the variable 'res' to silence this warning
>   int res;
>          ^
>           = 0