### PR TITLE
Fix extra space error in libetpan.pc.in

### DIFF
--- a/libetpan.pc.in
+++ b/libetpan.pc.in
@@ -6,5 +6,5 @@ libdir=@libdir@
 Name: libetpan
 Description: Libetpan C library.
 Version: @VERSION@
-Libs: -L${libdir} -letpan @LIBSUFFIX@ @LDFLAGS@ @SSLLIBS@ @GNUTLSLIB@ @LIBICONV@ @DBLIB@ @LIBS@ @SASLLIBS@
+Libs: -L${libdir} -letpan@LIBSUFFIX@ @LDFLAGS@ @SSLLIBS@ @GNUTLSLIB@ @LIBICONV@ @DBLIB@ @LIBS@ @SASLLIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Deleted an extra space between "-letpan" and  "@LIBSUFFIX@". The extra
space will cause build to fail if @LIBSUFFIX@ is not an empty string.