### PR TITLE
Fix mailmime_write(): add handler for MAILMIME_FIELD_LOCATION

### DIFF
--- a/src/low-level/mime/mailmime_write_generic.c
+++ b/src/low-level/mime/mailmime_write_generic.c
@@ -81,6 +81,9 @@ static int mailmime_version_write_driver(int (* do_write)(void *, const char *, 
 static int mailmime_encoding_write_driver(int (* do_write)(void *, const char *, size_t), void * data, int * col,
 				   struct mailmime_mechanism * encoding);
 
+static int mailmime_location_write_driver(int (* do_write)(void *, const char *, size_t), void *data, int *col,
+                                   char *location);
+
 static int mailmime_language_write_driver(int (* do_write)(void *, const char *, size_t), void * data, int * col,
 				   struct mailmime_language * language);
 
@@ -167,6 +170,10 @@ static int mailmime_field_write_driver(int (* do_write)(void *, const char *, si
 
   case MAILMIME_FIELD_LANGUAGE:
     r = mailmime_language_write_driver(do_write, data, col, field->fld_data.fld_language);
+    break;
+
+  case MAILMIME_FIELD_LOCATION:
+    r = mailmime_location_write_driver(do_write, data, col, field->fld_data.fld_location);
     break;
 
   default:
@@ -307,6 +314,33 @@ static int mailmime_encoding_write_driver(int (* do_write)(void *, const char *,
   * col = 0;
 #endif
   
+  return MAILIMF_NO_ERROR;
+}
+
+static int mailmime_location_write_driver(int (* do_write)(void *, const char *, size_t), void *data, int *col,
+                                   char *location)
+{
+  int r;
+  int len = strlen(location);
+
+  r = mailimf_string_write_driver(do_write, data, col, "Content-Location: ", 18);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
+  if (*col > 1 && *col + len > MAX_MAIL_COL) {
+    r = mailimf_string_write_driver(do_write, data, col, "\r\n ", 3);
+    if (r != MAILIMF_NO_ERROR)
+      return r;
+  }
+
+  r = mailimf_string_write_driver(do_write, data, col, location, len);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
+  r = mailimf_string_write_driver(do_write, data, col, "\r\n", 2);
+  if (r != MAILIMF_NO_ERROR)
+    return r;
+
   return MAILIMF_NO_ERROR;
 }
 


### PR DESCRIPTION
Hey,

I stumbled across a small 'bug' in mailmime_write(). As 'Content-locations' gets parsed correctly in mailmime_parse(), mailmime_write() failed when this field is present.

