### PR TITLE
Fix TLS timeouts with recent versions of GnuTLS

### DIFF
--- a/src/data-types/mailstream_ssl.c
+++ b/src/data-types/mailstream_ssl.c
@@ -636,7 +636,7 @@ static struct mailstream_ssl_data * ssl_data_new(int fd, time_t timeout,
 		timeout_value = mailstream_network_delay.tv_sec * 1000 + mailstream_network_delay.tv_usec / 1000;
   }
   else {
-		timeout_value = timeout;
+		timeout_value = timeout * 1000;
   }
 #if GNUTLS_VERSION_NUMBER >= 0x030100
 	gnutls_handshake_set_timeout(session, timeout_value);


### PR DESCRIPTION
`gnutls_handshake_set_timeout` takes a timeout value in ms, but we were providing a value in seconds. 

This means that on new-enough platforms that use GnuTLS (e.g., Debian Buster), we would accidentally configure a timeout 1,000 times shorter than requested.

In particular, I was seeing this when trying to use Delta Chat (https://github.com/deltachat/deltachat-core) in Debian. Compiled on Stretch, I could connect fine. Compiled on Buster, the connection always failed:

```
Trying: test@ur.gs test@ur.gs:***:ur.gs:143 test@ur.gs:***:ur.gs:587 AUTH_NORMAL IMAP_STARTTLS SMTP_STARTTLS
GnuTLS error: The operation timed out
IMAP stream lost; we'll reconnect soon.
[DC_EVENT_ERROR_NETWORK] first=1, msg=Could not connect to IMAP-server ur.gs:143 using STARTTLS. (Error #4)
IMAP disconnected.
```

Compiled on Stretch, the connection always succeeded. Delta sets a timeout of 10 seconds on its connections; 10ms is not long enough to negotiate SSL, but perhaps the mailimap default (30 seconds -> 30ms) is?

I tried running delta against a libetpan with this one-line patch, and it solved the problem for me.

This is preventing delta from getting into pureos for the librem5 linux mobile device: https://source.puri.sm/Librem5/chatty/issues/96