### PR TITLE
Add initial support for new versions TLS protocol.

### DIFF
--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -972,6 +972,9 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
       case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1:
         CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1);
         break;
+      case MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL:
+        CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelNegotiatedSSL);
+        break;
       case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1_1:
         CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1_1);
         break;
@@ -980,9 +983,6 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
         break;
       case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1_3:
         CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1_3);
-        break;
-      case MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL:
-        CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelNegotiatedSSL);
         break;
     }
     

--- a/src/data-types/mailstream_cfstream.c
+++ b/src/data-types/mailstream_cfstream.c
@@ -972,6 +972,15 @@ int mailstream_cfstream_set_ssl_enabled(mailstream * s, int ssl_enabled)
       case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1:
         CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1);
         break;
+      case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1_1:
+        CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1_1);
+        break;
+      case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1_2:
+        CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1_2);
+        break;
+      case MAILSTREAM_CFSTREAM_SSL_LEVEL_TLSv1_3:
+        CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelTLSv1_3);
+        break;
       case MAILSTREAM_CFSTREAM_SSL_LEVEL_NEGOCIATED_SSL:
         CFDictionarySetValue(settings, kCFStreamSSLLevel, kCFStreamSocketSecurityLevelNegotiatedSSL);
         break;


### PR DESCRIPTION
Gmail do not accept TLSv1 anymore.
Need add new versions of TLS protocol (TLSv1_1, TLSv1_2 and TLSv1_3)